### PR TITLE
improves form validation UX for create service form

### DIFF
--- a/src/cljs/admin/services/db.cljs
+++ b/src/cljs/admin/services/db.cljs
@@ -18,11 +18,19 @@
                     :rental      false
                     :fields      []})
 
+
+(def form-validation-defaults
+  {:name        true
+   :description true
+   :code        true})
+
+
 (def default-value
-  (merge {path {:from        ""
-                :to          ""
-                :service-id  nil
-                :search-text ""
-                :is-editing  false
-                :form        form-defaults}}
+  (merge {path {:from            ""
+                :to              ""
+                :service-id      nil
+                :search-text     ""
+                :is-editing      false
+                :form            form-defaults
+                :form-validation form-validation-defaults}}
          orders-db/default-value))

--- a/src/cljs/admin/services/events.cljs
+++ b/src/cljs/admin/services/events.cljs
@@ -408,7 +408,7 @@
  [(path db/path)]
  (fn [{db :db} _]
    (when (not-any? false? (vals (:form-validation db)))
-     {:dispatch [:service/create!]})))
+     {:dispatch [:service/create! (:form db)]})))
 
 
 (reg-event-fx

--- a/src/cljs/admin/services/events.cljs
+++ b/src/cljs/admin/services/events.cljs
@@ -384,9 +384,7 @@
  :service.form/clear
  [(path db/path)]
  (fn [db _]
-   (-> (update db :form dissoc :name :description :code :properties :catalogs :price :cost :rental :fields)
-       (assoc :form db/form-defaults)
-       (dissoc :form-validation)
+   (-> (assoc db :form db/form-defaults)
        (assoc :form-validation db/form-validation-defaults))))
 
 

--- a/src/cljs/admin/services/events.cljs
+++ b/src/cljs/admin/services/events.cljs
@@ -391,42 +391,43 @@
 (reg-event-fx
  :service.create/validate
  [(path db/path)]
- (fn [{db :db} _]
-   (let [name        (get-in db [:form :name])
-         description (get-in db [:form :description])
-         code        (get-in db [:form :code])]
+ (fn [{db :db} [_ form]]
+   (let [{name :name
+          description :description
+          code :code} form]
      {:db       (-> (assoc-in db [:form-validation :name] (not (empty? name)))
                     (assoc-in [:form-validation :description] (not (empty? description)))
                     (assoc-in [:form-validation :code] (not (or (empty? code)
                                                                  (contains? (set (map :code (norms/denormalize db :services/norms))) code)))))
-      :dispatch [::validate-create]})))
+      :dispatch [::validate-create form]})))
+
 
 (reg-event-fx
  ::validate-create
  [(path db/path)]
- (fn [{db :db} _]
+ (fn [{db :db} [_ form]]
    (when (not-any? false? (vals (:form-validation db)))
-     {:dispatch [:service/create! (:form db)]})))
+     {:dispatch [:service/create! form]})))
 
 
 (reg-event-fx
  :service.edit/validate
  [(path db/path)]
- (fn [{db :db} [_ service-id]]
-   (let [name (get-in db [:form :name])
-         description (get-in db [:form :description])]
+ (fn [{db :db} [_ service-id form]]
+   (let [{name :name
+          description :description} form]
      {:db (-> (assoc-in db [:form-validation :name] (not (empty? name)))
               (assoc-in [:form-validation :description] (not (empty? description)))
               (assoc-in [:form-validation :code] true)) ;; ensure that we don't check the code, since it could not have changed
-      :dispatch [::validate-edits service-id]})))
+      :dispatch [::validate-edits service-id form]})))
 
 
 (reg-event-fx
  ::validate-edits
  [(path db/path)]
- (fn [{db :db} [_ service-id]]
+ (fn [{db :db} [_ service-id form]]
    (when (not-any? false? (vals (:form-validation db)))
-     {:dispatch [:service/save-edits service-id (:form db)]})))
+     {:dispatch [:service/save-edits service-id form]})))
 
 
 (reg-event-fx

--- a/src/cljs/admin/services/subs.cljs
+++ b/src/cljs/admin/services/subs.cljs
@@ -83,3 +83,11 @@
  :<- [:services/list]
  (fn [services _]
    (vec (distinct (mapcat :catalogs services)))))
+
+
+
+(reg-sub
+ :service.form/is-valid?
+ :<-[db/path]
+ (fn [db [_ k]]
+   (get-in db [:form-validation k])))

--- a/src/cljs/admin/services/subs.cljs
+++ b/src/cljs/admin/services/subs.cljs
@@ -88,6 +88,6 @@
 
 (reg-sub
  :service.form/is-valid?
- :<-[db/path]
+ :<- [db/path]
  (fn [db [_ k]]
    (get-in db [:form-validation k])))

--- a/src/cljs/admin/services/views.cljs
+++ b/src/cljs/admin/services/views.cljs
@@ -381,7 +381,7 @@
       :visible     @(subscribe [:modal/visible? :service/create-service-form])
       :ok-text     "Save New Service"
       :on-cancel   #(dispatch [:service.form/hide])
-      :on-ok       #(dispatch [:service.create/validate])
+      :on-ok       #(dispatch [:service.create/validate @form])
       :after-close #(dispatch [:service.form/clear])}
 
      [create-service-form]]))
@@ -674,7 +674,7 @@
         {:on-click #(dispatch [:service/cancel-edit])}
         "Cancel"]
        [ant/button
-        {:on-click #(dispatch [:service.edit/validate @service-id])}
+        {:on-click #(dispatch [:service.edit/validate @service-id @form])}
         "Save Changes"]]]
      [create-service-form]]))
 

--- a/src/cljs/admin/services/views.cljs
+++ b/src/cljs/admin/services/views.cljs
@@ -257,14 +257,26 @@
       [:div.columns
        [:div.column.is-6
         [ant/form-item
-         {:label "Service Name"
-          :type  "text"}
+         (merge
+          {:label "service name"
+           :type  "text"}
+          (if @(subscribe [:service.form/is-valid? :name])
+            {}
+            {:help            "Please provide a name for this service."
+             :has-feedback    true
+             :validate-status "error"}))
          [ant/input
           {:placeholder "service name"
            :value       (:name @form)
            :on-change   #(dispatch [:service.form/update :name (.. % -target -value)])}]]
         [ant/form-item
-         {:label "Description"}
+         (merge
+          {:label "Description"}
+          (if @(subscribe [:service.form/is-valid? :description])
+            {}
+            {:help            "Please provide a description for this service."
+             :has-feedback    true
+             :validate-status "error"}))
          [ant/input-text-area
           {:rows        6
            :placeholder "description"
@@ -272,8 +284,15 @@
            :on-change   #(dispatch [:service.form/update :description (.. % -target -value)])}]]]
        [:div.column.is-4
         [ant/form-item
-         {:label "Code"
-          :type  "text"}
+         (merge
+          {:label "Code"
+           :type  "text"
+           :extra "This code must be unique to only this service."}
+          (if @(subscribe [:service.form/is-valid? :code])
+            {}
+            {:help            "Please provide a unique code for this service."
+             :has-feedback    true
+             :validate-status "error"}))
          [ant/input
           {:placeholder "service code"
            :value       (:code @form)
@@ -362,15 +381,7 @@
       :visible     @(subscribe [:modal/visible? :service/create-service-form])
       :ok-text     "Save New Service"
       :on-cancel   #(dispatch [:service.form/hide])
-      :on-ok       (fn []
-                     (let [{name        :name
-                            description :description
-                            code        :code} @form]
-                       (if (every? #(empty? %) [name description code])
-                         (ant/notification-error
-                          {:message     "Additional information required"
-                           :description "Please enter a name, description, and code for this service."})
-                         (dispatch [:service/create! @form]))))
+      :on-ok       #(dispatch [:service.create/validate])
       :after-close #(dispatch [:service.form/clear])}
 
      [create-service-form]]))

--- a/src/cljs/admin/services/views.cljs
+++ b/src/cljs/admin/services/views.cljs
@@ -580,17 +580,15 @@
          (if (nil? price)
            [:p "Quote"]
            [:p (str
-                "$"
-                price
-                (if (= :monthly billed)
-                  "/month"
-                  ""))])]]
+                (format/currency price)
+                (when (= :monthly billed)
+                  "/month"))])]]
        [:div.column.is-3
         [:div
          [:p [:b "Cost"]]
          (if (nil? cost)
            [:p "n/a"]
-           [:p (str "$" cost)])]]
+           [:p (format/currency cost)])]]
 
        [:div.column.is-3
         [:div

--- a/src/cljs/admin/services/views.cljs
+++ b/src/cljs/admin/services/views.cljs
@@ -674,7 +674,7 @@
         {:on-click #(dispatch [:service/cancel-edit])}
         "Cancel"]
        [ant/button
-        {:on-click #(dispatch [:service/save-edits @service-id @form])}
+        {:on-click #(dispatch [:service.edit/validate @service-id])}
         "Save Changes"]]]
      [create-service-form]]))
 


### PR DESCRIPTION
still only verifies that the `name` and `description` are not empty, and that the `code` is neither empty nor used by any other service