### PR TITLE
Add excluded/available days to UI

### DIFF
--- a/resources/graphql/input-objects.edn
+++ b/resources/graphql/input-objects.edn
@@ -143,12 +143,13 @@
 
   :service_field_object
   {:description "Custom fields to be defined when a new `service` is created."
-   :fields      {:index    {:type (non-null :Long)}
-                 :id       {:type :Long}
-                 :type     {:type (non-null :service_field_type)}
-                 :label    {:type (non-null String)}
-                 :required {:type Boolean}
-                 :options  {:type (list :service_field_option_object)}}}
+   :fields      {:index         {:type (non-null :Long)}
+                 :id            {:type :Long}
+                 :type          {:type (non-null :service_field_type)}
+                 :label         {:type (non-null String)}
+                 :required      {:type Boolean}
+                 :options       {:type (list :service_field_option_object)}
+                 :excluded_days {:type (list :Long)}}}
 
 
   :services_query_params

--- a/resources/graphql/mutations.edn
+++ b/resources/graphql/mutations.edn
@@ -265,7 +265,7 @@
    :resolve     :service/create!}
 
 
-    :service_update
+  :service_update
   {:type        :service
    :description "edit an existing premium service offering's details"
    :args        {:service_id {:type        (non-null Long)

--- a/resources/graphql/objects.edn
+++ b/resources/graphql/objects.edn
@@ -461,18 +461,20 @@
 
 
   :service_field
-  {:fields {:id       {:type    (non-null :Long)
-                       :resolve (:get :db/id)}
-            :index    {:type    (non-null Int)
-                       :resolve (:get :service-field/index)}
-            :type     {:type    :service_field_type
-                       :resolve (:keyword/name :service-field/type)}
-            :label    {:type    (non-null String)
-                       :resolve (:get :service-field/label)}
-            :required {:type    Boolean
-                       :resolve (:get :service-field/required)}
-            :options  {:type    (list :service_field_option)
-                       :resolve (:get :service-field/options)}}}
+  {:fields {:id            {:type    (non-null :Long)
+                            :resolve (:get :db/id)}
+            :index         {:type    (non-null Int)
+                            :resolve (:get :service-field/index)}
+            :type          {:type    :service_field_type
+                            :resolve (:keyword/name :service-field/type)}
+            :label         {:type    (non-null String)
+                            :resolve (:get :service-field/label)}
+            :required      {:type    Boolean
+                            :resolve (:get :service-field/required)}
+            :options       {:type    (list :service_field_option)
+                            :resolve (:get :service-field/options)}
+            :excluded_days {:type (list :Long)
+                            :resolve :service-field.date/excluded_days}}}
 
 
   :service_field_option

--- a/src/clj/odin/graphql/resolvers/service.clj
+++ b/src/clj/odin/graphql/resolvers/service.clj
@@ -52,6 +52,11 @@
          (c/to-date))))
 
 
+(defn excluded-days
+  [{conn :conn} _ field]
+  (:service-field.date/excluded-days field))
+
+
 ;; =============================================================================
 ;; Queries
 ;; =============================================================================
@@ -93,11 +98,12 @@
 
 
 (defn- parse-service-field
-  [{:keys [index type label required options]}]
+  [{:keys [index type label required excluded_days options]}]
   (service/create-field label type
-                        {:index    index
-                         :required required
-                         :options  (map parse-service-field-option options)}))
+                        {:index         index
+                         :required      required
+                         :excluded_days excluded_days
+                         :options       (map parse-service-field-option options)}))
 
 
 (defn- parse-mutate-params
@@ -157,8 +163,23 @@
       (concat field-options-tx))))
 
 
+(defn- update-date-excluded-days-tx
+  [db field existing-days days-params]
+  (let [existing     (if (some? existing-days) (set existing-days) #{})
+        updated      (set days-params)
+        [keep added] (map set ((juxt filter remove) (partial contains? existing) updated))
+        removed      (clojure.set/difference existing (clojure.set/union keep added))]
+
+    (cond-> []
+      (not (empty? added))
+      (concat (map #(vector :db/add (td/id field) :service-field.date/excluded-days %) added))
+
+      (not (empty? removed))
+      (concat (map #(vector :db/retract (td/id field) :service-field.date/excluded-days %) removed)))))
+
+
 (defn- update-field-tx
-  [db {:keys [id label index required options]}]
+  [db {:keys [id label index required excluded_days options]}]
   (let [e (d/entity db id)]
     (cond-> []
       (not= label (:service-field/label e))
@@ -167,8 +188,11 @@
       (not= index (:service-field/index e))
       (conj [:db/add id :service-field/index (int index)])
 
-      (not= required (:service-field/required required))
+      (not= required (:service-field/required e))
       (conj [:db/add id :service-field/required required])
+
+      (not= excluded_days (:service-field.date/excluded-days e))
+      (concat (update-date-excluded-days-tx db e (:service-field.date/excluded-days e) excluded_days))
 
       (and (some? options) (not (empty? options)))
       (concat (update-field-options-tx db e (:service-field/options e) options)))))
@@ -314,12 +338,13 @@
 
 (def resolvers
   {;; fields
-   :service/billed  billed
-   :service/type    svc-type
-   :service/updated updated
+   :service/billed                   billed
+   :service/type                     svc-type
+   :service/updated                  updated
+   :service-field.date/excluded_days excluded-days
    ;; mutations
-   :service/create! create!
-   :service/update! update!
+   :service/create!                  create!
+   :service/update!                  update!
    ;; queries
-   :service/query   query
-   :service/entry   entry})
+   :service/query                    query
+   :service/entry                    entry})

--- a/src/cljs/admin/services/subs.cljs
+++ b/src/cljs/admin/services/subs.cljs
@@ -96,6 +96,13 @@
  (fn [fields [_ {:keys [options]} option-index]]
    (= option-index (dec (count options)))))
 
+(reg-sub
+ :service.form.field.date/is-excluded?
+ :<- [:services.form/fields]
+ (fn [fields [_ index day]]
+   (let [excluded (get-in fields [index :excluded_days])]
+     (contains? excluded day))))
+
 
 (reg-sub
  :services/is-editing

--- a/src/cljs/iface/components/form.cljs
+++ b/src/cljs/iface/components/form.cljs
@@ -50,6 +50,34 @@
         ^{:key t} [ant/select-option {:value t} t]))]))
 
 
+
+;; ==============================================================================
+;; date picker component ========================================================
+;; ==============================================================================
+
+
+(defn- extract-day
+  [date]
+  (-> date
+      (js/moment)
+      (.day)))
+
+(defn date-picker
+  "Wraps the `ant/date-picker` component, overwriting the `disabled-date` prop with
+  a function that excludes any dates in the past, as well as any days provided in a
+  `disabled-days` prop (a vector of numbers, 0 - 6, which correspond to days of the week.)"
+  [{:keys [disabled-days] :as opts}]
+  [ant/date-picker
+   (assoc
+    opts
+    :disabled-date (fn [current]
+                     (let [day  (.day (js/moment current))]
+                       (or (when (some #(= day %) disabled-days)
+                             current)
+                           (and current
+                                (< (.valueOf current) (.valueOf (js/moment.))))))))])
+
+
 ;; ==============================================================================
 ;; add credit card form =========================================================
 ;; ==============================================================================

--- a/src/cljs/iface/components/services.cljs
+++ b/src/cljs/iface/components/services.cljs
@@ -37,13 +37,12 @@
   [:div.columns
    [:div.column
     [ant/form-item {:label (:label field)}
-     [ant/date-picker
+     [form/date-picker
       {:style         {:width "50%"}
        :value         (when-let [date (:value field)]
                         (js/moment date))
        :on-change     #(on-change (:index field) (when-let [x %] (.toISOString x)))
-       :disabled-date (fn [current]
-                        (and current (< (.valueOf current) (.valueOf (js/moment.)))))
+       :disabled-days [0 6]
        :show-today    false}]]]])
 
 
@@ -61,24 +60,6 @@
        :value       (when-let [time (:value field)]
                       (js/moment time))
        :on-change   #(on-change (:index field) (.toISOString %))}]]]])
-
-
-;; Are we keeping variants?
-#_(defmethod form-fields :variants [k fields {on-change :on-change}]
-  [:div
-   (map-indexed
-    (fn [i field]
-      ^{:key i}
-      [:div.columns
-       [:div.column
-        [ant/form-item {:label (:label field)}
-         [ant/radio-group
-          {:value     (keyword (:value field))
-           :on-change #(on-change (:key field) (.. % -target -value))}
-          (map-indexed
-           #(with-meta [ant/radio {:value (:key %2)} (:label %2)] {:key %1})
-           (:options field))]]]])
-    (get-fields fields k))])
 
 
 (defmethod form-fields :text [k field {on-change :on-change}]


### PR DESCRIPTION
admins can configure which days of the week a service is available, only those days are selectable in the member's date picker.  Dependent on changes to blueprints introduced in starcity-properties/blueprints#14
