### PR TITLE
extend license selection to be server-based

### DIFF
--- a/resources/graphql/objects.edn
+++ b/resources/graphql/objects.edn
@@ -549,6 +549,17 @@
                     :resolve (:get :svc-variant/price)}}}
 
 
+  :license_term
+  {:fields {:id        {:type    (non-null :Long)
+                        :resolve (:get :db/id)}
+            :term      {:type        (non-null :Long)
+                        :resolve     (:get :license/term)
+                        :description "The term in months."}
+            :available {:type        (non-null Boolean)
+                        :resolve     :license-term/available
+                        :description "Is this term available for members to select?"}}}
+
+
   :unit
   {:fields {:id       {:type    (non-null :Long)
                        :resolve (:get :db/id)}

--- a/resources/graphql/queries.edn
+++ b/resources/graphql/queries.edn
@@ -5,6 +5,11 @@
   :accounts        {:type    (list :account)
                     :args    {:params {:type :accounts_query_params}}
                     :resolve :account/list}
+  :license_terms   {:type    (list :license_term)
+                    :args    {:only_available {:type          Boolean
+                                               :default-value true
+                                               :description   "Only provide available license terms?"}}
+                    :resolve :license-term/list}
   :notes           {:type    (list :note)
                     :args    {:params {:type :notes_query_params}}
                     :resolve :note/query}

--- a/src/clj/odin/graphql/resolvers.clj
+++ b/src/clj/odin/graphql/resolvers.clj
@@ -5,6 +5,7 @@
             [odin.graphql.resolvers.application :as application]
             [odin.graphql.resolvers.check :as check]
             [odin.graphql.resolvers.deposit :as deposit]
+            [odin.graphql.resolvers.license-term :as license-term]
             [odin.graphql.resolvers.member-license :as member-license]
             [odin.graphql.resolvers.note :as note]
             [odin.graphql.resolvers.order :as order]
@@ -30,13 +31,14 @@
         application/resolvers
         check/resolvers
         deposit/resolvers
-        source/resolvers
+        license-term/resolvers
         member-license/resolvers
         note/resolvers
         order/resolvers
         payment/resolvers
         property/resolvers
         service/resolvers
+        source/resolvers
         referral/resolvers
         unit/resolvers)
        (reduce

--- a/src/clj/odin/graphql/resolvers/license_term.clj
+++ b/src/clj/odin/graphql/resolvers/license_term.clj
@@ -1,0 +1,51 @@
+(ns odin.graphql.resolvers.license-term
+  (:require [blueprints.models.account :as account]
+            [blueprints.models.license :as license]
+            [datomic.api :as d]
+            [odin.graphql.authorization :as authorization]))
+
+
+;; ==============================================================================
+;; resolvers ====================================================================
+;; ==============================================================================
+
+
+;; fields =======================================================================
+
+
+(defn available
+  [_ _ license]
+  (boolean (:license/available license)))
+
+
+;; queries ======================================================================
+
+
+(defn license-terms
+  [{:keys [conn]} {only_available :only_available} _]
+  (if only_available
+    (license/available (d/db conn))
+    (->> (d/q '[:find [?l ...]
+                :where
+                [?l :license/term _]]
+              (d/db conn))
+         (map (partial d/entity (d/db conn))))))
+
+
+;; authorization ================================================================
+
+
+;; only admins can query non-available license terms
+(defmethod authorization/authorized? :license-term/list
+  [_ account {:keys [only_available]}]
+  (or (account/admin? account) (true? only_available)))
+
+
+;; linking ======================================================================
+
+
+(def resolvers
+  {;; fields
+   :license-term/available available
+   ;; queries
+   :license-term/list      license-terms})

--- a/src/cljs/admin/accounts/events.cljs
+++ b/src/cljs/admin/accounts/events.cljs
@@ -304,6 +304,7 @@
  (fn [_ [_ account]]
    (let [current-community-id (get-in account [:property :id])]
      {:dispatch-n [[:modal/show db/reassign-modal-key]
+                   [:license-terms/query]
                    [:properties/query]
                    [:accounts.entry.reassign/update :fee true]
                    [:accounts.entry.reassign/update :community current-community-id]
@@ -531,7 +532,8 @@
  :accounts.entry.renewal/show
  [(path db/path)]
  (fn [{db :db} [_ license]]
-   {:dispatch-n [[:modal/show db/renewal-modal-key]
+   {:dispatch-n [[:license-terms/query]
+                 [:modal/show db/renewal-modal-key]
                  [:accounts.entry.renewal/populate license]]}))
 
 

--- a/src/cljs/admin/db.cljs
+++ b/src/cljs/admin/db.cljs
@@ -2,6 +2,7 @@
   (:require [admin.accounts.db :as accounts]
             [admin.overview.db :as overview]
             [admin.kami.db :as kami]
+            [admin.license-terms.db :as license-terms]
             [admin.metrics.db :as metrics]
             [admin.notes.db :as notes]
             [admin.profile.db :as profile]
@@ -41,6 +42,7 @@
    loading/db
    accounts/default-value
    kami/default-value
+   license-terms/default-value
    metrics/default-value
    notes/default-value
    payments/default-value

--- a/src/cljs/admin/events.cljs
+++ b/src/cljs/admin/events.cljs
@@ -3,6 +3,7 @@
             [admin.accounts.events]
             [admin.overview.events]
             [admin.kami.events]
+            [admin.license-terms.events]
             [admin.metrics.events]
             [admin.notes.events]
             [admin.profile.events]

--- a/src/cljs/admin/license_terms/db.cljs
+++ b/src/cljs/admin/license_terms/db.cljs
@@ -1,0 +1,8 @@
+(ns admin.license-terms.db)
+
+
+(def path ::path)
+
+
+(def default-value
+  {path {:license-terms []}})

--- a/src/cljs/admin/license_terms/events.cljs
+++ b/src/cljs/admin/license_terms/events.cljs
@@ -1,0 +1,23 @@
+(ns admin.license-terms.events
+  (:require [admin.license-terms.db :as db]
+            [re-frame.core :refer [path reg-event-db reg-event-fx]]))
+
+
+(reg-event-fx
+ :license-terms/query
+ [(path db/path)]
+ (fn [_ [k _]]
+   {:dispatch [:ui/loading k true]
+    :graphql  {:query
+               [[:license_terms {:only_available false}
+                 [:id :term :available]]]
+               :on-success [::license-terms-success k]
+               :on-failure [:graphql/failure k]}}))
+
+
+(reg-event-fx
+ ::license-terms-success
+ [(path db/path)]
+ (fn [{db :db} [_ k result]]
+   {:dispatch [:ui/loading k false]
+    :db       (assoc db :license-terms (get-in result [:data :license_terms]))}))

--- a/src/cljs/admin/license_terms/subs.cljs
+++ b/src/cljs/admin/license_terms/subs.cljs
@@ -1,0 +1,19 @@
+(ns admin.license-terms.subs
+  (:require [admin.license-terms.db :as db]
+            [re-frame.core :refer [reg-sub]]))
+
+
+(reg-sub
+ db/path
+ (fn [db _]
+   (db/path db)))
+
+
+(reg-sub
+ :license-terms/list
+ :<- [db/path]
+ (fn [db [_ {:keys [available]}]]
+   (let [terms (:license-terms db)]
+     (if available
+       (filter :available terms)
+       terms))))

--- a/src/cljs/admin/subs.cljs
+++ b/src/cljs/admin/subs.cljs
@@ -1,6 +1,7 @@
 (ns admin.subs
   (:require [admin.accounts.subs]
             [admin.kami.subs]
+            [admin.license-terms.subs]
             [admin.metrics.subs]
             [admin.notes.subs]
             [admin.profile.subs]


### PR DESCRIPTION
- adds `license_term` object to graphql
- provides a `license_terms` query that can be queried for all terms, or just the "available" ones (to members)
- select in transition modals uses data from server