### PR TITLE
Add bank account verification for community bank accounts

### DIFF
--- a/resources/graphql/objects.edn
+++ b/resources/graphql/objects.edn
@@ -451,26 +451,29 @@
 
 
   :property
-  {:fields {:id              {:type    (non-null :Long)
-                              :resolve (:get :db/id)}
-            :name            {:type    (non-null String)
-                              :resolve (:get :property/name)}
-            :code            {:type    (non-null String)
-                              :resolve (:get :property/internal-name)}
-            :bank_accounts   {:type    (list :property_bank_account)
-                              :resolve :property/bank-accounts}
-            :cover_image_url {:type    (non-null String)
-                              :resolve (:get :property/cover-image-url)}
-            :units           {:type    (list :unit)
-                              :resolve (:get :property/units)}
-            :rates           {:type    (list :rate)
-                              :resolve :property/license-prices}
-            :tours           {:type        (non-null Boolean)
-                              :description "Is touring enabled?"
-                              :resolve     :property/tours}
-            :has_financials  {:type        (non-null Boolean)
-                              :description "Does this community have financial information?"
-                              :resolve     :property/has-financials}}}
+  {:fields {:id                      {:type    (non-null :Long)
+                                      :resolve (:get :db/id)}
+            :name                    {:type    (non-null String)
+                                      :resolve (:get :property/name)}
+            :code                    {:type    (non-null String)
+                                      :resolve (:get :property/internal-name)}
+            :bank_accounts           {:type    (list :property_bank_account)
+                                      :resolve :property/bank-accounts}
+            :cover_image_url         {:type    (non-null String)
+                                      :resolve (:get :property/cover-image-url)}
+            :units                   {:type    (list :unit)
+                                      :resolve (:get :property/units)}
+            :rates                   {:type    (list :rate)
+                                      :resolve :property/license-prices}
+            :tours                   {:type        (non-null Boolean)
+                                      :description "Is touring enabled?"
+                                      :resolve     :property/tours}
+            :has_financials          {:type        (non-null Boolean)
+                                      :description "Does this community have financial information?"
+                                      :resolve     :property/has-financials}
+            :has_verified_financials {:type        (non-null Boolean)
+                                      :resolve     :property/has-verified-financials
+                                      :description "Has the financial information for this community been verified?"}}}
 
 
   :rate

--- a/src/clj/odin/graphql/resolvers/property.clj
+++ b/src/clj/odin/graphql/resolvers/property.clj
@@ -41,10 +41,9 @@
   (boolean (:entity (tproperty/by-community teller property))))
 
 
-<<<<<<< HEAD
-(defn bank-accounts
-  "Property banks"
-  [{:keys [teller]} _ property]
+(defn- bank-accounts*
+  "Given a community entity, fetch all bank accounts associated with this community."
+  [teller property]
   (let [teller-property (tproperty/by-community teller property)
         customer        (when (some? (:entity teller-property))
                           (tproperty/customer teller-property))
@@ -52,38 +51,28 @@
                           (tcustomer/sources c))]
     (when (some? sources)
       (->> (map
-        (fn [source]
-          {:id       (tsource/id source)
-           :verified (= :payment-source.status/verified (tsource/status source))
-           :type     (if (some? (tsource/payment-types source))
-                       :deposit
-                       :ops)})
-        sources)
+            (fn [source]
+              {:id       (tsource/id source)
+               :verified (= :payment-source.status/verified (tsource/status source))
+               :type     (if (some? (tsource/payment-types source))
+                           :deposit
+                           :ops)})
+            sources)
            (into [])))))
-=======
 
-(comment
-  (require '[teller.property :as tproperty])
 
-  (def mish (d/entity (d/db conn) [:property/code "2072mission"]))
-
-  )
+(defn bank-accounts
+  "Given a community entity, fetch all bank accounts associated with this community."
+  [{:keys [teller]} _ property]
+  (bank-accounts* teller property))
 
 
 (defn has-verified-financials
   "Has this community's financial information been verified?"
   [{:keys [teller]} _ property]
-  (clojure.pprint/pprint property)
-  ;;TODO - your code here!
-  false)
-
-
-(defn sources
-  "The source IDs for the bank accounts associated with this commnunity."
-  [{:keys [teller]} _ property]
-  ;;TODO - your code here!
-  nil)
->>>>>>> add verify community financials to admin UI
+  (->> (bank-accounts* teller property)
+       (some :verified)
+       (boolean)))
 
 
 ;; ==============================================================================
@@ -144,17 +133,8 @@
   (tproperty/business business_name tax_id owner address))
 
 
-<<<<<<< HEAD
 (defn- bank-account [{:keys [account_number routing_number account_type account_holder]}]
   (tproperty/bank-account account_number routing_number account_type account_holder))
-=======
-(defn- bank-account [{:keys [account_number routing_number]}]
-  (tproperty/bank-account account_number routing_number "business"
-                          {:account_holder_name "Jesse Suarez"
-                           :country             "US"
-                           :currency            "usd"
-                           :account_holder_type "company"}))
->>>>>>> add verify community financials to admin UI
 
 
 (defn- owner [{:keys [first_name last_name dob ssn]}]
@@ -253,17 +233,11 @@
 
 (def resolvers
   {;; fields
-<<<<<<< HEAD
-   :property/license-prices      license-prices
-   :property/tours               tours
-   :property/has-financials      has-financials
-   :property/bank-accounts       bank-accounts
-=======
    :property/license-prices          license-prices
    :property/tours                   tours
    :property/has-financials          has-financials
    :property/has-verified-financials has-verified-financials
->>>>>>> add verify community financials to admin UI
+   :property/bank-accounts       bank-accounts
    ;; mutations
    :property/add-financial-info!     add-financial-info!
    ;; :property/verify-financial-info!  verify-financial-info!

--- a/src/clj/odin/graphql/resolvers/property.clj
+++ b/src/clj/odin/graphql/resolvers/property.clj
@@ -52,7 +52,6 @@
     (when (some? sources)
       (->> (map
             (fn [source]
-              (println "\n\n-------- this payment source's status is..." (tsource/status source))
               {:id       (tsource/id source)
                :verified (= "verified" (tsource/status source))
                :type     (if (some? (tsource/payment-types source))

--- a/src/clj/odin/graphql/resolvers/property.clj
+++ b/src/clj/odin/graphql/resolvers/property.clj
@@ -70,9 +70,11 @@
 (defn has-verified-financials
   "Has this community's financial information been verified?"
   [{:keys [teller]} _ property]
-  (->> (bank-accounts* teller property)
-       (some :verified)
-       (boolean)))
+  (reduce
+   (fn [verified-so-far bank-account]
+     (and verified-so-far (:verified bank-account)))
+   true
+   (bank-accounts* teller property)))
 
 
 ;; ==============================================================================

--- a/src/clj/odin/graphql/resolvers/property.clj
+++ b/src/clj/odin/graphql/resolvers/property.clj
@@ -41,6 +41,7 @@
   (boolean (:entity (tproperty/by-community teller property))))
 
 
+<<<<<<< HEAD
 (defn bank-accounts
   "Property banks"
   [{:keys [teller]} _ property]
@@ -59,6 +60,30 @@
                        :ops)})
         sources)
            (into [])))))
+=======
+
+(comment
+  (require '[teller.property :as tproperty])
+
+  (def mish (d/entity (d/db conn) [:property/code "2072mission"]))
+
+  )
+
+
+(defn has-verified-financials
+  "Has this community's financial information been verified?"
+  [{:keys [teller]} _ property]
+  (clojure.pprint/pprint property)
+  ;;TODO - your code here!
+  false)
+
+
+(defn sources
+  "The source IDs for the bank accounts associated with this commnunity."
+  [{:keys [teller]} _ property]
+  ;;TODO - your code here!
+  nil)
+>>>>>>> add verify community financials to admin UI
 
 
 ;; ==============================================================================
@@ -119,8 +144,17 @@
   (tproperty/business business_name tax_id owner address))
 
 
+<<<<<<< HEAD
 (defn- bank-account [{:keys [account_number routing_number account_type account_holder]}]
   (tproperty/bank-account account_number routing_number account_type account_holder))
+=======
+(defn- bank-account [{:keys [account_number routing_number]}]
+  (tproperty/bank-account account_number routing_number "business"
+                          {:account_holder_name "Jesse Suarez"
+                           :country             "US"
+                           :currency            "usd"
+                           :account_holder_type "company"}))
+>>>>>>> add verify community financials to admin UI
 
 
 (defn- owner [{:keys [first_name last_name dob ssn]}]
@@ -139,6 +173,12 @@
                         :ops       (tproperty/connect-account business bops "daily")
                         :community community})
     (d/entity (d/db conn) (td/id community))))
+
+
+(defn verify-financial-info!
+  [{:keys [conn teller]} {:keys [params id]}]
+  ;;TODO - your code here!
+  (resolve/resolve-as nil {:message "this mutation has not been implemented yet!"}))
 
 
 ;; create =======================================================================
@@ -213,15 +253,23 @@
 
 (def resolvers
   {;; fields
+<<<<<<< HEAD
    :property/license-prices      license-prices
    :property/tours               tours
    :property/has-financials      has-financials
    :property/bank-accounts       bank-accounts
+=======
+   :property/license-prices          license-prices
+   :property/tours                   tours
+   :property/has-financials          has-financials
+   :property/has-verified-financials has-verified-financials
+>>>>>>> add verify community financials to admin UI
    ;; mutations
-   :property/add-financial-info! add-financial-info!
-   :property/create!             create!
-   :property/set-rate!           set-rate!
-   :property/toggle-touring!     toggle-touring!
+   :property/add-financial-info!     add-financial-info!
+   ;; :property/verify-financial-info!  verify-financial-info!
+   :property/create!                 create!
+   :property/set-rate!               set-rate!
+   :property/toggle-touring!         toggle-touring!
    ;; queries
-   :property/entry               entry
-   :property/query               query})
+   :property/entry                   entry
+   :property/query                   query})

--- a/src/clj/odin/graphql/resolvers/property.clj
+++ b/src/clj/odin/graphql/resolvers/property.clj
@@ -52,8 +52,9 @@
     (when (some? sources)
       (->> (map
             (fn [source]
+              (println "\n\n-------- this payment source's status is..." (tsource/status source))
               {:id       (tsource/id source)
-               :verified (= :payment-source.status/verified (tsource/status source))
+               :verified (= "verified" (tsource/status source))
                :type     (if (some? (tsource/payment-types source))
                            :deposit
                            :ops)})

--- a/src/cljs/admin/properties/subs.cljs
+++ b/src/cljs/admin/properties/subs.cljs
@@ -81,3 +81,10 @@
  :<- [db/path]
  (fn [db [_]]
    (:financial-form db)))
+
+
+(reg-sub
+ :verify/form
+ :<- [db/path]
+ (fn [db [_]]
+   (:verify-accounts db)))

--- a/src/cljs/admin/properties/views.cljs
+++ b/src/cljs/admin/properties/views.cljs
@@ -14,7 +14,8 @@
             [iface.components.typography :as typography]
             [admin.routes :as routes]
             [iface.loading :as loading]
-            [admin.notes.views :as notes]))
+            [admin.notes.views :as notes]
+            [iface.utils.log :as log]))
 
 ;; What do we want to be able to see in a property's detail view?
 
@@ -210,9 +211,53 @@
      [add-financial-info-form form]]))
 
 
+(defn verify-financial-info-form []
+  [:div
+   [ant/card
+    {:title "Operations Account"
+     :extra (r/as-element [ant/button "Verify"])}
+    [:div.columns
+     [:div.column.is-half
+      [ant/form-item
+       {:label "First amount"}
+       [ant/input-number
+        {:placeholder "¢"}]]]
+     [:div.column.is-half
+      [ant/form-item
+       {:label "Second amount"}
+       [ant/input-number
+        {:placeholder "¢"}]]]]]
+
+   [ant/card
+    {:title "Operations Account"
+     :extra (r/as-element [ant/button "Verify"])}
+    [:div.columns
+     [:div.column.is-half
+      [ant/form-item
+       {:label "First amount"}
+       [ant/input-number
+        {:placeholder "¢"}]]]
+     [:div.column.is-half
+      [ant/form-item
+       {:label "Second amount"}
+       [ant/input-number
+        {:placeholder "¢"}]]]]]])
+
+
+(defn verify-financial-info-modal []
+  [ant/modal
+   {:title     "Verify Financial Information"
+    :width     "40%"
+    :on-ok     #(dispatch [:community/verify-financial-info!])
+    :ok-text   "Verify Information"
+    :on-cancel #(dispatch [:community.verify-financial/cancel])
+    :visible   @(subscribe [:modal/visible? :community.verify-financial/modal])}
+   [verify-financial-info-form]])
+
+
 (defn property-card
   "Display a property as a card form."
-  [{:keys [id name cover-image-url href is-loading has-financials]
+  [{:keys [id name cover-image-url href is-loading has-financials has-verified-financials]
     :or   {is-loading false, href "#"}
     :as   props}]
   [ant/card {:class   "is-flush"
@@ -229,14 +274,22 @@
      [:a {:href href}
       "Details "
       [ant/icon {:type "right"}]]
-     (when-not has-financials
-       [ant/button
-        {:style    {:float "right"}
-         :size     :small
-         :icon     "plus"
-         :on-click #(dispatch [:community.add-financial/show {:id   id
-                                                              :name name}])}
-        "Add financial information"])]]])
+     (when-not has-verified-financials
+       (if-not has-financials
+         [ant/button
+          {:style    {:float "right"}
+           :size     :small
+           :icon     "plus"
+           :on-click #(dispatch [:community.add-financial/show {:id   id
+                                                                :name name}])}
+          "Add financial information"]
+         [ant/button
+          {:style {:float "right"}
+           :size :small
+           :icon "check"
+           :on-click #(dispatch [:community.verify-financial/show])}
+
+          "Verify Financial Info"]))]]])
 
 
 (defn- unit-list-item
@@ -273,7 +326,7 @@
     :or   {page-size 10, active false}}]
   (let [state (r/atom {:current 1 :q ""})]
     (fn [{:keys [units page-size active on-click]
-          :or   {page-size 10, active false}}]
+         :or   {page-size 10, active false}}]
       (let [{:keys [current q]} @state
             units'               (->> (drop (* (dec current) page-size) units)
                                       (take (* current page-size))
@@ -476,15 +529,16 @@
 (defn community-row [communities]
   [:div.columns
    (map
-    (fn [{:keys [id name cover_image_url units has_financials]}]
+    (fn [{:keys [id name cover_image_url units has_financials has_verified_financials]}]
       ^{:key id}
       [:div.column.is-4
        [property-card
-        {:id              id
-         :name            name
-         :cover-image-url cover_image_url
-         :href            (routes/path-for :properties/entry :property-id id)
-         :has-financials  has_financials}]])
+        {:id                      id
+         :name                    name
+         :cover-image-url         cover_image_url
+         :href                    (routes/path-for :properties/entry :property-id id)
+         :has-financials          has_financials
+         :has-verified-financials has_verified_financials}]])
     communities)])
 
 
@@ -502,6 +556,7 @@
   (let [is-loading (subscribe [:ui/loading? :properties/query])]
     [:div
      [add-financial-info-modal]
+     [verify-financial-info-modal]
      [create-community-modal]
      (typography/view-header "Communities" "Manage and view our communities.")
      (if @is-loading


### PR DESCRIPTION
- Implements field resolvers for `has_verified_financials` on a `property`
- Conditionally renders "add financial info" and "verify financial info" buttons on community cards in the admin communities view
- Adds UI to enter microdeposits for Ops and Deposit bank accounts and verify them (individually)