### PR TITLE
Add Security Deposit Refund

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -58,8 +58,8 @@
                  [cljsjs/moment "2.17.1-1"]
                  [akiroz.re-frame/storage "0.1.2"]
                  ;; DB
-                 [starcity/teller "1.3.0"]
-                 [starcity/blueprints "2.6.2"
+                 [starcity/teller "1.3.1-SNAPSHOT"]
+                 [starcity/blueprints "2.7.0-SNAPSHOT"
                   :exclusions [com.datomic/datomic-free
                                com.andrewmcveigh/cljs-time
                                com.google.guava/guava

--- a/resources/graphql/enums.edn
+++ b/resources/graphql/enums.edn
@@ -23,6 +23,10 @@
   {:description "Possible statuses of the security deposit refund."
    :values      [:initiated :successful :failed]}
 
+  :line_item_type
+  {:description "Possible types of the line items."
+   :values      [:rent :ffe :cleaning :repairs :interest]}
+
   :license_status
   {:description "Possible statuses of a member license."
    :values      [:active :inactive :canceled :renewal :pending]}
@@ -42,6 +46,10 @@
   :payment_type
   {:description "Different types of payment."
    :values      [:order :rent :deposit :fee :application_fee :guest_booking :late_fee]}
+
+  :bank_account_type
+  {:description "Property bank account types."
+   :values      [:ops :deposit]}
 
   :payments_date_key
   {:description "Allowed keys for date-based payment queries."

--- a/resources/graphql/input-objects.edn
+++ b/resources/graphql/input-objects.edn
@@ -88,12 +88,14 @@
     :to         {:type        :Instant
                  :description "Orders until."}}}
 
+
   :mutate_line_item_params
   {:description "Parameters to create a line item."
    :fields      {:id    {:type :Long}
                  :desc  {:type (non-null String)}
                  :cost  {:type Float}
-                 :price {:type (non-null Float)}}}
+                 :price {:type (non-null Float)}
+                 :types {:type (list :line_item_type)}}}
 
 
   :mutate_order_params
@@ -156,6 +158,31 @@
                  :datekey      {:type          :payments_date_key
                                 :default-value :created
                                 :description   "Specifies which date attribute to use for date params."}}}
+
+
+  ;;; Payout Account
+  :create_payout_params
+  {:description "Inputs to create a payout account."
+   :fields      {:routing_number {:type        (non-null :String)
+                                  :description "Bank Routing Number"}
+                 :account_number {:type        (non-null :String)
+                                  :description "Bank Account Number"}
+                 :dob            {:type        (non-null :Instant)
+                                  :description "Date of Birth of Member"}
+                 :ssn            {:type        (non-null :String)
+                                  :description "SSN of Member"}
+                 :line1          {:type        (non-null :String)
+                                  :description "Line1 of Address"}
+                 :line2          {:type        :String
+                                  :description "Line2 of Address"}
+                 :city           {:type        (non-null :String)
+                                  :description "City of Address"}
+                 :state          {:type        (non-null :String)
+                                  :description "State of Address"}
+                 :postal_code    {:type        (non-null :String)
+                                  :description "Postal code of Address"}
+                 :country        {:type        (non-null :String)
+                                  :description "Country of Address"}}}
 
 
   ;;; Note
@@ -261,18 +288,20 @@
   ;;; Communities - previously properties
   :bank_account_create_params
   {:fields {:account_number {:type (non-null String)}
+            :account_type   {:type (non-null String)}
+            :account_holder {:type (non-null String)}
             :routing_number {:type (non-null String)}}}
 
   :community_add_financial_info_params
   {:description "Parameters to add financial information to a community."
-   :fields      {:deposit       {:type (non-null :bank_account_create_params)}
-                 :ops           {:type (non-null :bank_account_create_params)}
-                 :first_name    {:type (non-null String)}
-                 :last_name     {:type (non-null String)}
-                 :dob           {:type :Instant}
-                 :ssn           {:type (non-null String)}
-                 :business_name {:type (non-null String)}
-                 :tax_id        {:type (non-null String)}}}
+   :fields      {:deposit        {:type (non-null :bank_account_create_params)}
+                 :ops            {:type (non-null :bank_account_create_params)}
+                 :first_name     {:type (non-null String)}
+                 :last_name      {:type (non-null String)}
+                 :dob            {:type :Instant}
+                 :ssn            {:type (non-null String)}
+                 :business_name  {:type (non-null String)}
+                 :tax_id         {:type (non-null String)}}}
 
   :community_create_params
   {:description "Parameters to create a new community"

--- a/resources/graphql/mutations.edn
+++ b/resources/graphql/mutations.edn
@@ -257,6 +257,19 @@
    :resolve     :payment.sources/set-default!}
 
 
+  ;; payout account================================================================
+
+
+  :create_payout_account
+  {:type        :account
+   :description "Create a payout account for legacy customers to refund their security deposit"
+   :args        {:id {:type (non-null :Long)
+                      :description "The id of the account"}
+                 :params {:type :create_payout_params}}
+   :resolve     :account/create-payout!}
+
+
+
   ;; properties ===================================================================
 
 
@@ -313,6 +326,18 @@
                               :description "The service's id"}
                  :params     {:type :service_update_params}}
    :resolve     :service/update!}
+
+
+  ;; refund security deposit ======================================================
+
+
+  :refund_security_deposit
+  {:type        :deposit
+   :description "Payout the remainder of the security deposit."
+   :args        {:deposit_id {:type (non-null :Long)}
+                 :credits    {:type (list :mutate_line_item_params)}
+                 :charges    {:type (list :mutate_line_item_params)}}
+   :resolve     :deposit/refund!}
 
 
   ;; units ========================================================================

--- a/resources/graphql/objects.edn
+++ b/resources/graphql/objects.edn
@@ -451,26 +451,29 @@
 
 
   :property
-  {:fields {:id              {:type    (non-null :Long)
-                              :resolve (:get :db/id)}
-            :name            {:type    (non-null String)
-                              :resolve (:get :property/name)}
-            :code            {:type    (non-null String)
-                              :resolve (:get :property/internal-name)}
-            :bank_accounts   {:type    (list :property_bank_account)
-                              :resolve :property/bank-accounts}
-            :cover_image_url {:type    (non-null String)
-                              :resolve (:get :property/cover-image-url)}
-            :units           {:type    (list :unit)
-                              :resolve (:get :property/units)}
-            :rates           {:type    (list :rate)
-                              :resolve :property/license-prices}
-            :tours           {:type        (non-null Boolean)
-                              :description "Is touring enabled?"
-                              :resolve     :property/tours}
-            :has_financials  {:type        (non-null Boolean)
-                              :description "Does this community have financial information?"
-                              :resolve     :property/has-financials}}}
+  {:fields {:id                      {:type    (non-null :Long)
+                                      :resolve (:get :db/id)}
+            :name                    {:type    (non-null String)
+                                      :resolve (:get :property/name)}
+            :code                    {:type    (non-null String)
+                                      :resolve (:get :property/internal-name)}
+            :bank_accounts           {:type    (list :property_bank_account)
+                                      :resolve :property/bank-accounts}
+            :cover_image_url         {:type    (non-null String)
+                                      :resolve (:get :property/cover-image-url)}
+            :units                   {:type    (list :unit)
+                                      :resolve (:get :property/units)}
+            :rates                   {:type    (list :rate)
+                                      :resolve :property/license-prices}
+            :tours                   {:type        (non-null Boolean)
+                                      :description "Is touring enabled?"
+                                      :resolve     :property/tours}
+            :has_financials          {:type        (non-null Boolean)
+                                      :description "Does this community have financial information?"
+                                      :resolve     :property/has-financials}
+            :has_verified_financials {:type        (non-null Boolean)
+                                      :resolve     :property/has-verified-financials
+                                      :description "Has the financial information for this community been verified?"}}}
 
 
   :rate

--- a/resources/graphql/objects.edn
+++ b/resources/graphql/objects.edn
@@ -36,6 +36,12 @@
                                     :resolve (:get :person/phone-number)}
                 :property          {:type    :property
                                     :resolve :account/property}
+                :refundable        {:type    (non-null :Boolean)
+                                    :resolve :account/refundable}
+                :refunded          {:type    (non-null :Boolean)
+                                    :resolve :account/refunded}
+                :payout_account    {:type    (non-null :Boolean)
+                                    :resolve :account/payout-account}
                 :role              {:type    (non-null :role)
                                     :resolve :account/role}
                 :service_source    {:type        :payment_source
@@ -172,7 +178,9 @@
                                :resolve     :deposit/amount-pending}
             :refund_status    {:type        :deposit_refund_status
                                :description "The status of the refund, if any."
-                               :resolve     :deposit/refund-status}}}
+                               :resolve     :deposit/refund-status}
+            :line_items       {:type    (list :line_item)
+                               :resolve :deposit/line-items}}}
 
 
   :emergency_contact
@@ -350,7 +358,9 @@
             :cost  {:type    Float
                     :resolve (:get :line-item/cost)}
             :price {:type    (non-null Float)
-                    :resolve (:get :line-item/price)}}}
+                    :resolve (:get :line-item/price)}
+            :types {:type    (list :Keyword)
+                    :resolve (:get :line-item/types)}}}
 
 
   :payment
@@ -430,6 +440,16 @@
                        :description "Payments associated with this source."
                        :resolve     :payment-source/payments}}}
 
+
+  :property_bank_account
+  {:fields {:id       {:type    (non-null :String)
+                       :resolve (:get :id)}
+            :verified {:type    (non-null :Boolean)
+                       :resolve (:get :verified)}
+            :type     {:type    (non-null :bank_account_type)
+                       :resolve (:get :type)}}}
+
+
   :property
   {:fields {:id              {:type    (non-null :Long)
                               :resolve (:get :db/id)}
@@ -437,6 +457,8 @@
                               :resolve (:get :property/name)}
             :code            {:type    (non-null String)
                               :resolve (:get :property/internal-name)}
+            :bank_accounts   {:type    (list :property_bank_account)
+                              :resolve :property/bank-accounts}
             :cover_image_url {:type    (non-null String)
                               :resolve (:get :property/cover-image-url)}
             :units           {:type    (list :unit)

--- a/src/clj/migrations/teller/properties.clj
+++ b/src/clj/migrations/teller/properties.clj
@@ -24,7 +24,7 @@
   [teller conn]
   (doseq [[cid ops-id deposit-id] (query-communities (d/db conn))]
     (let [p    (d/entity (d/db conn) cid)
-          fees (tproperty/construct-fees (tproperty/fee 0))]
+          fees (tproperty/construct-fees (tproperty/format-fee 0))]
       (tproperty/create! teller
                          (property/code p)
                          (property/name p)

--- a/src/clj/odin/graphql.clj
+++ b/src/clj/odin/graphql.clj
@@ -3,13 +3,12 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as string]
-            [cheshire.core :as json]
             [com.walmartlabs.lacinia.schema :as schema]
             [com.walmartlabs.lacinia.util :as util]
             [datomic.api :as d]
             [mount.core :refer [defstate]]
-            [odin.graphql.resolvers :as resolvers]
-            [taoensso.timbre :as timbre]))
+            [odin.graphql.resolvers :as resolvers]))
+
 
 (defn- parse-keyword [s]
   (let [[ns' n'] (string/split s #"/")]
@@ -85,6 +84,15 @@
 
     )
 
+  (let [account (d/entity (d/db conn) [:account/email "member@test.com"])]
+    (execute schema
+             (venia/graphql-query
+              {:venia/queries
+               [[:account {:id (:db/id account)}
+                 [[:deposit [:id :due :amount [:line_items [:id]]]]]]]})
+             nil
+             ctx))
+
 
   (let [account (d/entity (d/db conn) [:account/email "member@test.com"])]
     (execute schema
@@ -101,7 +109,7 @@
      (execute schema
               (venia/graphql-query
                {:venia/queries
-                [[:payments {:account (:db/id account)}
+                [[:payments {:params {:account (:db/id account)}}
                   [:id :type [:order [:id]] [:property [:name]]]]]})
               nil
               ctx)))

--- a/src/clj/odin/graphql/resolvers/deposit.clj
+++ b/src/clj/odin/graphql/resolvers/deposit.clj
@@ -128,7 +128,7 @@
             customer (tcustomer/by-account teller account)
             amount   (refund-amount (deposit/amount deposit) charges credits)]
         (cond
-          (utils-deposit/is-refundable? deposit)
+          (utils-deposit/is-refunded? deposit)
           (resolve/resolve-as nil {:message "Member has already been refunded their security deposit"})
 
           (nil? (tcustomer/payout-account-id customer))

--- a/src/clj/odin/graphql/resolvers/deposit.clj
+++ b/src/clj/odin/graphql/resolvers/deposit.clj
@@ -1,10 +1,16 @@
 (ns odin.graphql.resolvers.deposit
-  (:require [blueprints.models.security-deposit :as deposit]
-            [clj-time.core :as t]
+  (:require [blueprints.models.event :as event]
+            [blueprints.models.security-deposit :as deposit]
             [clj-time.coerce :as c]
+            [clj-time.core :as t]
+            [com.walmartlabs.lacinia.resolve :as resolve]
+            [datomic.api :as d]
+            [odin.graphql.resolvers.utils :refer [error-message]]
+            [odin.graphql.resolvers.utils.deposit :as utils-deposit]
+            [taoensso.timbre :as timbre]
+            [teller.customer :as tcustomer]
             [teller.payment :as tpayment]
-            [teller.customer :as tcustomer]))
-
+            [toolbelt.datomic :as td]))
 
 ;; =============================================================================
 ;; Fields
@@ -50,6 +56,113 @@
     (keyword (name s))))
 
 
+(defn line-items
+  [_ _ deposit]
+  (deposit/line-items deposit))
+
+
+(defn- sum-amount [items]
+  (reduce
+   (fn [sum item]
+     (cond
+       (number? (:price item))
+       (+ sum (:price item))
+
+       :else
+       sum))
+   0
+   items))
+
+
+(defn- refund-amount
+  [deposit-amount charges credits]
+  (let [charge-amount (sum-amount charges)
+        credit-amount (sum-amount credits)
+        refund-amount (-> deposit-amount
+                          (- charge-amount)
+                          (+ credit-amount))]
+    (if (number? refund-amount)
+      refund-amount
+      0)))
+
+
+(defn- create-associated-payments!
+  [customer charges credits]
+  (let [property        (tcustomer/property customer)
+        charge-payments (doall
+                         (map
+                          (fn [{price :price}]
+                            (tpayment/create! customer price :payment.type/deposit {:subtypes [:deposit-refund-charge]
+                                                                                    :status   :payment.status/paid
+                                                                                    :paid-on  (java.util.Date.)
+                                                                                    :property property}))
+                          charges))
+        credit-payments (doall
+                         (map
+                          (fn [{price :price}]
+                            (tpayment/create! customer price :payment.type/deposit {:subtypes [:deposit-refund-credit]
+                                                                                    :status   :payment.status/paid
+                                                                                    :paid-on  (java.util.Date.)
+                                                                                    :property property}))
+                          credits))]
+    (concat charge-payments credit-payments)))
+
+
+(defn- line-item-data
+  [line-items subtype]
+  (map
+   (fn [{desc :desc price :price types :types}]
+     {:line-item/desc  desc
+      :line-item/price price
+      :line-item/types types
+      :line-item/subtypes subtype})
+   line-items))
+
+
+(defn refund!
+  [{:keys [teller conn] :as ctx} {:keys [deposit_id charges credits] :as params} _]
+  (let [deposit (d/entity (d/db conn) deposit_id)]
+    (if (nil? deposit)
+      (resolve/resolve-as nil {:message "Member does not have a security deposit"})
+      (let [account  (deposit/account deposit)
+            customer (tcustomer/by-account teller account)
+            amount   (refund-amount (deposit/amount deposit) charges credits)]
+        (cond
+          (utils-deposit/is-refundable? deposit)
+          (resolve/resolve-as nil {:message "Member has already been refunded their security deposit"})
+
+          (nil? (tcustomer/payout-account-id customer))
+          (resolve/resolve-as nil {:message "Member does not have a payout account."})
+
+          (> amount (deposit/amount deposit))
+          (resolve/resolve-as nil {:message "Refund amount is above security deposit."})
+
+          (> 0 amount)
+          (resolve/resolve-as nil {:message "Refund amount is below security deposit."})
+
+          :else
+          (try
+            (when-let [payment (tcustomer/pay! customer amount :payment.type/deposit {:subtypes   [:deposit-refund]
+                                                                                      :absorb-fee true})]
+              (let [assoc-payments (create-associated-payments! customer charges credits)]
+                (->> [{:db/id                 deposit_id
+                       :deposit/refund-status :deposit.refund-status/successful
+                       :deposit/lines         (concat
+                                               (line-item-data charges :refund-charge)
+                                               (line-item-data credits :refund-credit))}
+                      {:db/id              (td/id payment)
+                       :payment/associated (map
+                                            #(td/id %)
+                                            assoc-payments)}
+                      (event/job :deposit/refund {:params {:deposit-id deposit_id
+                                                           :account-id (td/id account)}})]
+                     (d/transact conn)
+                     (deref)))
+              (d/entity (d/db conn) deposit_id))
+            (catch Throwable t
+              (timbre/error t ::refund! {:email (tcustomer/email customer)})
+              (resolve/resolve-as nil {:message (error-message t)}))))))))
+
 ;; =============================================================================
 ;; Resolvers
 ;; =============================================================================
@@ -62,4 +175,6 @@
    :deposit/amount-pending   amount-pending
    :deposit/payments         payments
    :deposit/refund-status    refund-status
-   :deposit/status           deposit-status})
+   :deposit/status           deposit-status
+   :deposit/refund!          refund!
+   :deposit/line-items       line-items})

--- a/src/clj/odin/graphql/resolvers/payment_source.clj
+++ b/src/clj/odin/graphql/resolvers/payment_source.clj
@@ -18,7 +18,8 @@
             [teller.property :as tproperty]
             [teller.source :as tsource]
             [teller.subscription :as tsubscription]
-            [toolbelt.core :as tb]))
+            [toolbelt.core :as tb]
+            [clojure.string :as str]))
 
 ;; =============================================================================
 ;; Fields

--- a/src/clj/odin/graphql/resolvers/property.clj
+++ b/src/clj/odin/graphql/resolvers/property.clj
@@ -8,7 +8,9 @@
             [com.walmartlabs.lacinia.resolve :as resolve]
             [datomic.api :as d]
             [odin.graphql.authorization :as authorization]
+            [teller.customer :as tcustomer]
             [teller.property :as tproperty]
+            [teller.source :as tsource]
             [toolbelt.core :as tb]
             [toolbelt.datomic :as td]))
 
@@ -37,6 +39,26 @@
   "Do we have financial information?"
   [{:keys [teller]} _ property]
   (boolean (:entity (tproperty/by-community teller property))))
+
+
+(defn bank-accounts
+  "Property banks"
+  [{:keys [teller]} _ property]
+  (let [teller-property (tproperty/by-community teller property)
+        customer        (when (some? (:entity teller-property))
+                          (tproperty/customer teller-property))
+        sources         (when-some [c customer]
+                          (tcustomer/sources c))]
+    (when (some? sources)
+      (->> (map
+        (fn [source]
+          {:id       (tsource/id source)
+           :verified (= :payment-source.status/verified (tsource/status source))
+           :type     (if (some? (tsource/payment-types source))
+                       :deposit
+                       :ops)})
+        sources)
+           (into [])))))
 
 
 ;; ==============================================================================
@@ -97,12 +119,8 @@
   (tproperty/business business_name tax_id owner address))
 
 
-(defn- bank-account [{:keys [account_number routing_number]}]
-  (tproperty/bank-account account_number routing_number
-                          {:account_holder_name "Jesse Suarez"
-                           :country             "US"
-                           :currency            "usd"
-                           :account_holder_type "company"}))
+(defn- bank-account [{:keys [account_number routing_number account_type account_holder]}]
+  (tproperty/bank-account account_number routing_number account_type account_holder))
 
 
 (defn- owner [{:keys [first_name last_name dob ssn]}]
@@ -117,8 +135,8 @@
         bdeposit  (bank-account (:deposit params))
         bops      (bank-account (:ops params))]
     (tproperty/create! teller (property/code community) (property/name community) account-holder-email
-                       {:deposit   (tproperty/connect-account business bdeposit)
-                        :ops       (tproperty/connect-account business bops)
+                       {:deposit   (tproperty/connect-account business bdeposit "daily")
+                        :ops       (tproperty/connect-account business bops "daily")
                         :community community})
     (d/entity (d/db conn) (td/id community))))
 
@@ -198,6 +216,7 @@
    :property/license-prices      license-prices
    :property/tours               tours
    :property/has-financials      has-financials
+   :property/bank-accounts       bank-accounts
    ;; mutations
    :property/add-financial-info! add-financial-info!
    :property/create!             create!

--- a/src/clj/odin/graphql/resolvers/property.clj
+++ b/src/clj/odin/graphql/resolvers/property.clj
@@ -41,9 +41,9 @@
   (boolean (:entity (tproperty/by-community teller property))))
 
 
-(defn bank-accounts
-  "Property banks"
-  [{:keys [teller]} _ property]
+(defn- bank-accounts*
+  "Given a community entity, fetch all bank accounts associated with this community."
+  [teller property]
   (let [teller-property (tproperty/by-community teller property)
         customer        (when (some? (:entity teller-property))
                           (tproperty/customer teller-property))
@@ -51,14 +51,30 @@
                           (tcustomer/sources c))]
     (when (some? sources)
       (->> (map
-        (fn [source]
-          {:id       (tsource/id source)
-           :verified (= :payment-source.status/verified (tsource/status source))
-           :type     (if (some? (tsource/payment-types source))
-                       :deposit
-                       :ops)})
-        sources)
+            (fn [source]
+              {:id       (tsource/id source)
+               :verified (= "verified" (tsource/status source))
+               :type     (if (some? (tsource/payment-types source))
+                           :deposit
+                           :ops)})
+            sources)
            (into [])))))
+
+
+(defn bank-accounts
+  "Given a community entity, fetch all bank accounts associated with this community."
+  [{:keys [teller]} _ property]
+  (bank-accounts* teller property))
+
+
+(defn has-verified-financials
+  "Has this community's financial information been verified?"
+  [{:keys [teller]} _ property]
+  (reduce
+   (fn [verified-so-far bank-account]
+     (and verified-so-far (:verified bank-account)))
+   true
+   (bank-accounts* teller property)))
 
 
 ;; ==============================================================================
@@ -141,6 +157,12 @@
     (d/entity (d/db conn) (td/id community))))
 
 
+(defn verify-financial-info!
+  [{:keys [conn teller]} {:keys [params id]}]
+  ;;TODO - your code here!
+  (resolve/resolve-as nil {:message "this mutation has not been implemented yet!"}))
+
+
 ;; create =======================================================================
 
 
@@ -213,15 +235,17 @@
 
 (def resolvers
   {;; fields
-   :property/license-prices      license-prices
-   :property/tours               tours
-   :property/has-financials      has-financials
+   :property/license-prices          license-prices
+   :property/tours                   tours
+   :property/has-financials          has-financials
+   :property/has-verified-financials has-verified-financials
    :property/bank-accounts       bank-accounts
    ;; mutations
-   :property/add-financial-info! add-financial-info!
-   :property/create!             create!
-   :property/set-rate!           set-rate!
-   :property/toggle-touring!     toggle-touring!
+   :property/add-financial-info!     add-financial-info!
+   ;; :property/verify-financial-info!  verify-financial-info!
+   :property/create!                 create!
+   :property/set-rate!               set-rate!
+   :property/toggle-touring!         toggle-touring!
    ;; queries
-   :property/entry               entry
-   :property/query               query})
+   :property/entry                   entry
+   :property/query                   query})

--- a/src/clj/odin/graphql/resolvers/utils/deposit.clj
+++ b/src/clj/odin/graphql/resolvers/utils/deposit.clj
@@ -26,7 +26,7 @@
       :deposit.refund-status/initiated} (deposit/refund-status deposit))))
 
 (s/fdef is-refunded?
-        :args (s/cat :deposit td/entity?)
+        :args (s/cat :deposit td/entityd?)
         :ret boolean?)
 
 

--- a/src/clj/odin/graphql/resolvers/utils/deposit.clj
+++ b/src/clj/odin/graphql/resolvers/utils/deposit.clj
@@ -1,0 +1,50 @@
+(ns odin.graphql.resolvers.utils.deposit
+  (:require [blueprints.models.account :as account]
+            [blueprints.models.security-deposit :as deposit]
+            [clojure.spec.alpha :as s]
+            [teller.core :as teller]
+            [teller.customer :as tcustomer]
+            [teller.payment :as tpayment]
+            [toolbelt.datomic :as td]))
+
+(defn has-payout-account?
+  [teller account]
+  (some? (when-let [c (tcustomer/by-account teller account)]
+           (tcustomer/payout-account-id c))))
+
+(s/fdef has-payout-account?
+        :args (s/cat :teller teller/connection?
+                     :deposit td/entityd?)
+        :ret boolean?)
+
+
+(defn is-refunded?
+  "Has this deposit refund proccess been initiated or successful?"
+  [deposit]
+  (some?
+   (#{:deposit.refund-status/successful
+      :deposit.refund-status/initiated} (deposit/refund-status deposit))))
+
+(s/fdef is-refunded?
+        :args (s/cat :deposit td/entity?)
+        :ret boolean?)
+
+
+(defn is-refundable?
+  "Can this security deposit be refunded?"
+  [teller deposit]
+  (let [customer (tcustomer/by-account teller (deposit/account deposit))]
+    (and (nil? (deposit/refund-status deposit))
+         (not (empty? (deposit/payments deposit)))
+         (let [charge-total (->> (deposit/payments deposit)
+                                 (map (partial tpayment/by-entity teller))
+                                 (filter #(tpayment/paid? %1))
+                                 (reduce #(+ %1 (tpayment/amount %2)) 0))]
+           (= (deposit/amount deposit) charge-total))
+         (has-payout-account? teller (deposit/account deposit))
+         (false? (is-refunded? deposit)))))
+
+(s/fdef is-refundable?
+        :args (s/cat :teller teller/connection?
+                     :deposit td/entityd?)
+        :ret boolean?)

--- a/src/cljs/admin/accounts/db.cljs
+++ b/src/cljs/admin/accounts/db.cljs
@@ -26,15 +26,37 @@
    :sort-by       :unit})
 
 
+(def default-validation
+  {:desc  true
+   :types true
+   :price true})
+
+
+(def default-key-value
+  nil)
+
+
+(def default-line-item
+  {:desc  default-key-value
+   :types default-key-value
+   :price default-key-value})
+
+
 (def default-value
   {path {;; list
-         :params default-params
+         :params                  default-params
          ;; entry
-         :units            []
-         :tab              nil
-         :create-form      {}
-         :reassign-form    {}
-         :transition-form  {}}})
+         :units                   []
+         :tab                     nil
+         :create-form             {}
+         :reassign-form           {}
+         :transition-form         {}
+         ;; security deposit refund
+         :types                   [:rent :ffe :cleaning :repairs :interest]
+         :charges-form-validation []
+         :credits-form-validation []
+         :form                    {:charges []
+                                   :credits []}}})
 
 
 ;; entry ========================================================================

--- a/src/cljs/admin/accounts/events.cljs
+++ b/src/cljs/admin/accounts/events.cljs
@@ -8,7 +8,8 @@
             [re-frame.core :refer [reg-event-fx
                                    reg-event-db
                                    path]]
-            [toolbelt.core :as tb]))
+            [toolbelt.core :as tb]
+            [taoensso.timbre :as timbre]))
 
 
 ;; ==============================================================================
@@ -61,8 +62,8 @@
      {:dispatch [:ui/loading k true]
       :graphql   {:query
                   [[:account {:id account-id}
-                    [:id :name :email :phone :role :dob
-                     [:deposit [:amount :due :status]]
+                    [:id :name :email :phone :role :dob :refundable :refunded
+                     [:deposit [:id :amount :due :refund_status :status [:line_items [:desc :types :price]]]]
                      [:property [:id :name]]
                      ;; TODO: Move to separate query
                      [:application [:id :move_in :created :updated :submitted :status :term :has_pet
@@ -519,6 +520,7 @@
                  :on-success [::move-out-success k]
                  :on-failure [:graphql/failure k]}}))
 
+
 (reg-event-fx
  :accounts.entry.renewal/populate
  [(path db/path)]
@@ -643,6 +645,76 @@
      {:dispatch-n [[:ui/loading k false]
                    [:notify/success "Transition deleted!"]
                    [:account/fetch account-id]]})))
+
+
+;; refund security deposit ======================================================
+
+
+(reg-event-fx
+ :security-deposit.line-item/create
+ [(path db/path)]
+ (fn [{db :db} [_ refund-type]]
+   {:db (-> (update-in db [:form refund-type] conj db/default-line-item)
+            (update-in [(keyword (str (name refund-type) "-form-validation"))]
+                       conj
+                       db/default-validation))}))
+
+
+(defn- parse-price
+  [k v]
+  (if (and (= k :price)
+           (or (js/Number.isNaN v) (< v 0)))
+    nil
+    v))
+
+
+(reg-event-db
+ :security-deposit.line-item/update
+ [(path db/path)]
+ (fn [db [_ idx refund-type key value]]
+   (let [value (parse-price key value)]
+     (assoc-in db [:form refund-type idx key] value))))
+
+
+(reg-event-db
+ :security-deposit.line-item/delete
+ [(path db/path)]
+ (fn [db [_ idx refund-type]]
+   (update-in db [:form refund-type] #(tb/remove-at % idx))))
+
+
+(defn prepare-edits
+  [items]
+  (mapv
+   (fn [item]
+     (tb/transform-when-key-exists item
+       {:types #(vector (clojure.core/keyword %))}))
+   items))
+
+
+(reg-event-fx
+ :security-deposit/refund!
+ [(path db/path)]
+ (fn [{db :db} [k account-id deposit-id credits charges]]
+   {:dispatch [:ui/loading k true]
+    :graphql  {:mutation
+               [[:refund_security_deposit {:deposit_id deposit-id
+                                           :credits    (prepare-edits credits)
+                                           :charges    (prepare-edits charges)}
+                 [:id]]]
+               :on-success [::security-deposit-success k account-id]
+               :on-failure [:graphql/failure k]}}))
+
+
+(reg-event-fx
+ ::security-deposit-success
+ [(path db/path)]
+ (fn [db [_ k account-id]]
+   {:dispatch-n [[:ui/loading k false]
+                 [:modal/hide :security-deposit/modal]
+                 [:account/fetch account-id {:on-success [::on-fetch-account]}]
+                 [:payments/fetch account-id]
+                 [:notify/success "Security Deposit refunded!"]]}))
 
 
 ;; payment ======================================================================

--- a/src/cljs/admin/accounts/subs.cljs
+++ b/src/cljs/admin/accounts/subs.cljs
@@ -39,6 +39,160 @@
    (:application (norms/get-norm db :accounts/norms account-id))))
 
 
+(defn- sum-amount [items]
+  (reduce
+   (fn [sum item]
+     (cond
+       (number? (:price item))
+       (+ sum (:price item))
+
+       :else
+       sum))
+   0
+   items))
+
+
+(reg-sub
+ :security-deposit/sum-amount
+ (fn [_ [_ items]]
+   (sum-amount items)))
+
+
+(defn- refund-amount
+  [deposit-amount form]
+  (let [charge-amount (sum-amount (:charges form))
+        credit-amount (sum-amount (:credits form))
+        refund-amount (-> deposit-amount
+                          (- charge-amount)
+                          (+ credit-amount))]
+    (if (js/Number.isNaN refund-amount)
+      0
+      refund-amount)))
+
+(reg-sub
+ :security-deposit/refund-amount
+ :<- [:security-deposit/form]
+ (fn [form [_ deposit-amount]]
+   (refund-amount deposit-amount form)))
+
+
+(defn- some-item?
+  [item]
+  (and (not= db/default-key-value item)
+       (some? item)))
+
+
+(defn- some-item-str?
+  [item]
+  (and (some-item? item)
+       (when (string? item)
+         (not (empty? item)))))
+
+
+(defn- validate-items
+  [line-items]
+  (reduce
+   (fn [result {desc :desc types :types price :price}]
+     (conj result {:desc  (some-item-str? desc)
+                   :types (some-item? types)
+                   :price (and (number? price)
+                               (<= 0 price))}))
+   []
+   line-items))
+
+
+(defn- valid-form-items?
+  [items]
+  (boolean
+   (reduce
+    (fn [return item]
+      (if (some false? (vals item))
+        (reduced false)
+        return))
+    true
+    items)))
+
+
+(defn- valid-form?
+  [db]
+  (and (valid-form-items? (:charges-form-validation db))
+       (valid-form-items? (:credits-form-validation db))))
+
+
+(defn- can-submit?
+  [deposit-amount form]
+  (let [refund-amount (refund-amount deposit-amount form)]
+    (false? (or (js/Number.isNaN refund-amount)
+                (> refund-amount deposit-amount)
+                (> 0 refund-amount)))) )
+
+
+(defn- form-validation
+  [db]
+  (let [charges (get-in db [:form :charges])
+        credits (get-in db [:form :credits])]
+    (-> (assoc-in {} [:charges-form-validation] (validate-items charges))
+        (assoc-in [:credits-form-validation] (validate-items credits)))))
+
+
+(reg-sub
+ :security-deposit.form/validation
+ :<- [db/path]
+ (fn [db _]
+   (form-validation db)))
+
+
+(reg-sub
+ :security-deposit/can-submit?
+ :<- [db/path]
+ (fn [db [_ deposit-amount]]
+   (and (valid-form? (form-validation db))
+        (can-submit? deposit-amount (:form db)))))
+
+
+(reg-sub
+ :security-deposit.line-item/is-valid?
+ :<- [:security-deposit.form/validation]
+ (fn [db [_ k refund-type item idx]]
+   (or (= db/default-key-value (k item))
+       (get-in db [(keyword (str (name refund-type) "-form-validation")) idx k]))))
+
+
+(reg-sub
+ :security-deposit/refundable?
+ (fn [_ [_ account]]
+   (let [refunded (:refunded account)]
+     (cond
+       refunded
+       "Member has already been refunded their deposit."
+
+       (not (:refundable account))
+       "Member does not have a payout account. Please inform the member to where
+       to input details to be refunded their security deposit."
+
+       :else nil))))
+
+
+(reg-sub
+ :security-deposit/input-value
+ (fn [_ [_ item k]]
+   (let [value (k item)]
+     (when-not (= db/default-key-value value) value))))
+
+
+(reg-sub
+ :security-deposit/form
+ :<- [db/path]
+ (fn [db _]
+   (:form db)))
+
+
+(reg-sub
+ :security-deposit/types
+ :<- [db/path]
+ (fn [db _]
+   (:types db)))
+
 
 ;; ==============================================================================
 ;; list =========================================================================

--- a/src/cljs/admin/profile/membership/events.cljs
+++ b/src/cljs/admin/profile/membership/events.cljs
@@ -29,7 +29,7 @@
  (fn [_ [k account-id]]
    {:dispatch [:ui/loading k true]
     :graphql  {:query      [[:account {:id account-id}
-                             [[:deposit [:id :due :amount :amount_remaining :amount_paid :amount_pending]]
+                             [[:deposit [:id :due :amount :amount_remaining :amount_paid :amount_pending :line_items]]
                               [:active_license
                                [:id :rate :starts :ends :status :term
                                 [:unit [:id :number]]

--- a/src/cljs/admin/properties/events.cljs
+++ b/src/cljs/admin/properties/events.cljs
@@ -24,8 +24,8 @@
    {:dispatch [:ui/loading k true]
     :graphql  {:query
                [[:properties
-                 [:id :name :code :cover_image_url
-                  :has_financials
+                 [:id :name :code :cover_image_url :has_financials
+                  [:bank_accounts [:id :verified :type]]
                   [:units [:id]]]]]
                :on-success [::properties-query k params]
                :on-failure [:graphql/failure k]}}))
@@ -108,19 +108,21 @@
 
 (defn- create-bank-account-params [{:keys [account-number routing-number]}]
   {:account_number account-number
+   :account_type   "company"
+   :account_holder "Jesse Suarez"
    :routing_number routing-number})
 
 
 (defn- create-financial-info-params
   [{:keys [business-name tax-id first-name last-name ssn dob deposit ops]}]
-  {:business_name business-name
-   :tax_id        tax-id
-   :first_name    first-name
-   :last_name     last-name
-   :ssn           ssn
-   :dob           dob
-   :deposit       (create-bank-account-params deposit)
-   :ops           (create-bank-account-params ops)})
+  {:business_name  business-name
+   :tax_id         tax-id
+   :first_name     first-name
+   :last_name      last-name
+   :ssn            ssn
+   :dob            dob
+   :deposit        (create-bank-account-params deposit)
+   :ops            (create-bank-account-params ops)})
 
 
 (reg-event-fx

--- a/src/cljs/admin/properties/events.cljs
+++ b/src/cljs/admin/properties/events.cljs
@@ -9,7 +9,8 @@
                                    reg-event-fx
                                    path]]
             [taoensso.timbre :as timbre]
-            [toolbelt.core :as tb]))
+            [toolbelt.core :as tb]
+            [iface.utils.log :as log]))
 
 
 ;; ==============================================================================
@@ -24,7 +25,8 @@
    {:dispatch [:ui/loading k true]
     :graphql  {:query
                [[:properties
-                 [:id :name :code :cover_image_url :has_financials
+                 [:id :name :code :cover_image_url
+                  :has_financials :has_verified_financials
                   [:bank_accounts [:id :verified :type]]
                   [:units [:id]]]]]
                :on-success [::properties-query k params]
@@ -74,6 +76,9 @@
 
 (defmethod routes/dispatches :properties/list [_]
   [[:properties/query]])
+
+
+;; add financials =======================
 
 
 (reg-event-fx
@@ -147,6 +152,74 @@
                    [:properties/query]
                    [:modal/hide :community.add-financial/modal]]
       :db         (update-in db [:form] dissoc :financial)})))
+
+
+;; verify financials ====================
+
+
+(reg-event-fx
+ :community.verify-financial/show
+ [(path db/path)]
+ (fn [{db :db} [k bank-accounts]]
+   {:dispatch-n [[:modal/show :community.verify-financial/modal]
+                 [:community.verify-financial/init bank-accounts]]}))
+
+
+(defn- prepare-bank-accounts
+  "Given a set of bank accounts for a community, produce a data structure that can
+  be used in the community.verify-finanical modal"
+  [bank-accounts]
+  (reduce
+   (fn [m {:keys [type] :as bank-account}]
+     (assoc m type (dissoc bank-account :type)))
+   {}
+   bank-accounts))
+
+
+(reg-event-fx
+ :community.verify-financial/init
+ [(path db/path)]
+ (fn [{db :db} [_ bank-accounts]]
+   {:db (assoc db :verify-accounts (prepare-bank-accounts bank-accounts))}))
+
+
+(reg-event-fx
+ :community.verify-financial/update
+ [(path db/path)]
+ (fn [{db :db} [_ bank-account-type microdeposit amount]]
+   (log/log "updating financial info..." bank-account-type microdeposit amount)
+   {:db (assoc-in db [:verify-accounts bank-account-type microdeposit] amount)}))
+
+
+(reg-event-fx
+ :community/verify-financial-info!
+ [(path db/path)]
+ (fn [{db :db} [k account-type {:keys [id first second] :as account}]]
+   (log/log "verifying bank acount" account-type id first second)
+   {:dispatch [:ui/loading k true]
+    :graphql  {:mutation
+               [[:verify_bank_source {:deposits [first second]
+                                      :id       id}
+                 [:id]]]
+               :on-success [::verify-financial-info-success]
+               :on-failure [:graphql/failure k]}}))
+
+
+(reg-event-fx
+ ::verify-financial-info-success
+ [(path db/path)]
+ (fn [{db :db} [_ k response]]
+   (log/log "successfully verified bank account info")
+   {:dispatch-n [[:ui/loading k false]
+                 [:community.verify-financial/close]
+                 [:properties/query]]}))
+
+(reg-event-fx
+ :community.verify-financial/close
+ [(path db/path)]
+ (fn [{db :db} _]
+   {:dispatch [:modal/hide :community.verify-financial/modal]
+    :db       (dissoc db :verify-accounts)}))
 
 
 (defn- create-address-params [{:keys [address] :as params}]

--- a/src/cljs/admin/properties/subs.cljs
+++ b/src/cljs/admin/properties/subs.cljs
@@ -81,3 +81,10 @@
  :<- [db/path]
  (fn [db [_]]
    (:financial-form db)))
+
+
+(reg-sub
+ :verify/form
+ :<- [db/path]
+ (fn [db [_]]
+   (:verify-accounts db)))

--- a/src/cljs/iface/modules/payments.cljs
+++ b/src/cljs/iface/modules/payments.cljs
@@ -120,7 +120,7 @@
                [[:payment_sources {:account account-id}
                  [:id :last4 :customer :type :name :default :status :autopay :expires
                   [:payments [:id :method :type :autopay :amount :status :pstart :pend :paid_on :description]]
-                  [:account [:id]]]]]
+                  [:account [:id :first_name :last_name :dob :refundable :payout_account]]]]]
                :on-success [::fetch-success k account-id opts]
                :on-failure [:graphql/failure k]}}))
 

--- a/src/cljs/member/events.cljs
+++ b/src/cljs/member/events.cljs
@@ -7,7 +7,8 @@
             [member.profile.events]
             [member.services.events]
             [re-frame.core :refer [reg-event-db reg-event-fx path]]
-            [iface.utils.formatters :as format]))
+            [iface.utils.formatters :as format]
+            [antizer.reagent :as ant]))
 
 
 (graphql/configure
@@ -29,7 +30,8 @@
  ::fetch-membership-status
  (fn [{:keys [db]} [_ account-id]]
    {:graphql {:query      [[:account {:id account-id}
-                            [[:deposit [:id :due :amount :amount_remaining :amount_paid :amount_pending]]
+                            [:refundable :payout_account
+                             [:deposit [:id :due :amount :amount_remaining :amount_paid :amount_pending]]
                              [:active_license [[:payments [:amount :status :due]]]]]]]
               :on-success [::fetch-success]
               :on-failure [:graphql/failure]}}))
@@ -56,6 +58,19 @@
                    :danger)))
 
 
+(defn- payout-account-missing-message []
+  (notifs/create :payout-account-missing
+                 [ant/tooltip {:title "We can send your deposit directly to your
+                  bank when we know how much to return, but we’ll need some more
+                  info first."}
+                  [:span
+                   [:b "We need a little more info."]
+                   " Can you go to " [:u "Payment Methods"] " and click “Add
+                   Deposit Info”? Thanks!"]]
+                 (routes/path-for :profile.payment/sources)
+                 :warning))
+
+
 (defn- messages [{:keys [account] :as data}]
   (let [due-payments (->> (get-in account [:active_license :payments])
                           (filter #(= (:status %) :due)))
@@ -65,7 +80,10 @@
       (conj (rent-due-message (first due-payments)))
 
       (and (> (:amount_remaining deposit) 0) (t/is-before-now (:due deposit)))
-      (conj (deposit-overdue-message deposit)))))
+      (conj (deposit-overdue-message deposit))
+
+      (false? (:payout_account account))
+      (conj (payout-account-missing-message)))))
 
 
 (reg-event-fx

--- a/src/cljs/member/profile/membership/views.cljs
+++ b/src/cljs/member/profile/membership/views.cljs
@@ -250,7 +250,6 @@
 (defn other-payments-card
   "Renders a card for payments that are neither rent nor deposits, with a CTA to pay"
   [sources payment]
-  (.log js/console payment)
   [ant/card
    [:div.columns
     [:div.column.is-2

--- a/src/cljs/member/profile/payments/sources/db.cljs
+++ b/src/cljs/member/profile/payments/sources/db.cljs
@@ -7,13 +7,41 @@
 (def add-path ::add-source)
 
 
+(def add-payout ::payout-account)
+
+
+(def default-key-value
+  nil)
+
+(def char-limit
+  {:routing-number 9
+   :account-number 12
+   :ssn 9
+   :state 2
+   :country 2
+   :postal-code 5})
+
+
 (def default-value
-  {path     {:sources        []
-             :current        nil
-             :autopay        {:on false :source nil}
-             :loading        {:list false}}
-   add-path {:type            :bank
-             :card            {}
-             :bank            {}
-             :microdeposits   {:amount-1 nil :amount-2 nil}
-             :available-types [:bank :card]}})
+  {path       {:sources []
+               :current nil
+               :autopay {:on false :source nil}
+               :loading {:list false}}
+   add-path   {:type            :bank
+               :card            {}
+               :bank            {}
+               :microdeposits   {:amount-1 nil :amount-2 nil}
+               :available-types [:bank :card]}
+   add-payout {:form            {:line1 default-key-value
+                                 :line2 default-key-value
+                                 :city default-key-value
+                                 :state default-key-value
+                                 :postal-code default-key-value
+                                 :country default-key-value
+
+                                 :dob default-key-value
+                                 :ssn default-key-value
+
+                                 :routing-number default-key-value
+                                 :account-number default-key-value}
+               :form-validation {}}})

--- a/src/cljs/member/profile/payments/sources/subs.cljs
+++ b/src/cljs/member/profile/payments/sources/subs.cljs
@@ -1,13 +1,20 @@
 (ns member.profile.payments.sources.subs
   (:require [member.profile.payments.sources.db :as db]
             [re-frame.core :as rf :refer [reg-sub]]
-            [toolbelt.core :as tb]))
+            [toolbelt.core :as tb]
+            [iface.utils.time :as time]))
 
 
 (reg-sub
  ::sources
  (fn [db _]
    (db/path db)))
+
+
+(reg-sub
+ ::payout-account
+ (fn [db _]
+   (db/add-payout db)))
 
 
 ;; =============================================================================
@@ -107,6 +114,107 @@
  :<- [::add-source]
  (fn [db _]
    (:microdeposits db)))
+
+
+;; ==============================================================================
+;; Add Deposit Payout Account ===================================================
+;; ==============================================================================
+
+
+(reg-sub
+ :payment/account
+ :<- [:payment/sources]
+ (fn [sources _]
+   (:account (first sources))))
+
+
+(reg-sub
+ :account/payout-account
+ :<- [:payment/account]
+ (fn [account _]
+   (:payout_account account)))
+
+
+(reg-sub
+ :payout-account/form
+ :<- [::payout-account]
+ (fn [db _]
+   (:form db)))
+
+
+(defn- some-item?
+  [item]
+  (and (not= db/default-key-value item)
+       (some? item)))
+
+
+(defn- some-item-str?
+  ([item]
+   (and (some-item? item)
+        (when (string? item)
+          (not (empty? item)))))
+  ([item num]
+   (and (some-item-str? item)
+        (= num (count item)))))
+
+
+(defn- form-validation
+  [{:keys [line1 line2 city state postal-code country
+           dob ssn routing-number account-number]}]
+  {;; Address
+   :line1       (some-item-str? line1)
+   ;; :line2       (some-item-str? line2) ;; Ignore since it's optional
+   :city        (some-item-str? city)
+   :state       (some-item-str? state (:state db/char-limit))
+   :postal-code (some-item-str? postal-code (:postal-code db/char-limit))
+   :country     (some-item-str? country (:country db/char-limit))
+
+   ;; Personal
+   :dob (some-item? dob)
+   :ssn (some-item-str? ssn (:ssn db/char-limit))
+
+   ;; Bank
+   :routing-number (some-item-str? routing-number (:routing-number db/char-limit))
+   :account-number (some-item-str? account-number (:account-number db/char-limit))})
+
+
+(reg-sub
+ :payout-account.form/validation
+ :<- [:payout-account/form]
+ (fn [form _]
+   (form-validation form)))
+
+(reg-sub
+ :payout-account.form/is-valid?
+ :<- [:payout-account.form/validation]
+ :<- [:payout-account/form]
+ (fn [[vdb form] [_ k]]
+   (or (= db/default-key-value (k form))
+       (k vdb)
+       (= k :line2))))
+
+
+(reg-sub
+ :payout-account/can-submit?
+ :<- [:payout-account.form/validation]
+ (fn [db _]
+   (every? true? (vals db))))
+
+
+(reg-sub
+ :payout-account/input-value
+ :<- [:payout-account/form]
+ (fn [form [_ k]]
+   (let [value (k form)]
+     (when-not (= db/default-key-value value) value))))
+
+
+(reg-sub
+ :payout-account.date/default-date
+ (fn [_]
+   (-> (js/moment (time/now))
+       (.subtract 13 "year" )
+       (.subtract 1 "day"))))
 
 
 ;; =============================================================================

--- a/src/cljs/member/profile/payments/sources/views.cljs
+++ b/src/cljs/member/profile/payments/sources/views.cljs
@@ -1,17 +1,16 @@
 (ns member.profile.payments.sources.views
   (:require [antizer.reagent :as ant]
+            [iface.components.form :as form]
+            [iface.components.payments :as payments]
+            [iface.components.typography :as typography]
             [iface.media :as media]
             [iface.tooltip :as tooltip]
-            [iface.components.form :as form]
-            [iface.components.typography :as typography]
-            [iface.components.payments :as payments]
             [member.l10n :as l10n]
             [member.profile.payments.sources.views.forms :as forms]
             [member.routes :as routes]
-            [reagent.core :as r]
             [re-frame.core :refer [dispatch subscribe]]
-            [toolbelt.core :as tb]))
-
+            [reagent.core :as r]
+            [clojure.string :as str]))
 
 (defn- is-unverified [{:keys [type status] :as source}]
   (and (= type :bank) (not= status "verified")))
@@ -350,12 +349,182 @@
      (into [:span] (r/children this))]))
 
 
+(defn- payout-confirmation-content [form]
+  [:div
+   [:p "Before submitting, please make sure your information is correct."]])
+
+
+(defn- payout-confirmation-modal []
+  (let [account @(subscribe [:payment/account])
+        form @(subscribe [:payout-account/form])]
+    (ant/modal-confirm
+     {:title   "Confirm Deposit Information"
+      :content (r/as-element [payout-confirmation-content form])
+      :on-type :primary
+      :ok-text "Confirm!"
+      :on-ok   #(dispatch [:payout-account/create! (:id account)])})))
+
+
+(defn- payout-modal-footer []
+  (let [is-loading (subscribe [:ui/loading? :payout-account/create!])
+        can-submit (subscribe [:payout-account/can-submit?])
+        on-cancel  #(dispatch [:modal/hide :payout-account/modal])]
+    [:div
+     [ant/button
+      {:on-click #(on-cancel)}
+      "Cancel"]
+     [ant/tooltip
+      {:title (when (not @can-submit)
+                "Please fill or fix all required fields.")}
+      [ant/button
+       {:loading  @is-loading
+        :disabled (not @can-submit)
+        :on-click #(payout-confirmation-modal)
+        :type     :primary}
+       "Submit!"]]]))
+
+
+(defn- payout-dob []
+  (let [is-valid (subscribe [:payout-account.form/is-valid? :dob])
+        value (subscribe [:payout-account/input-value :dob])
+        default-date (subscribe [:payout-account.date/default-date])
+        on-change #(dispatch [:payout-account.form/update! :dob %])]
+    [ant/form-item
+     (merge
+      {:label "Date of Birth:"
+       :read-only true}
+      (if @is-valid
+        {}
+        {:help            "Please provide your date of birth."
+         :has-feedback    true
+         :validate-status "error"}))
+     [ant/date-picker
+      {:value @value
+       :default-value @default-date
+       :disabled-date #(> % @default-date)
+       :allow-clear false
+       :format "MMM Do YY"
+       :on-change #(on-change %)}]]))
+
+
+(defn- payout-field
+  [{:keys [k label help required]}]
+  (let [is-valid  (subscribe [:payout-account.form/is-valid? k])
+        value     (subscribe [:payout-account/input-value k])
+        on-change #(dispatch [:payout-account.form/update! k %])]
+    [ant/form-item
+     (merge
+      {:label     label
+       :read-only true}
+      (if @is-valid
+        {}
+        {:help            help
+         :has-feedback    true
+         :validate-status "error"}))
+     [ant/input
+      {:value @value
+       :placeholder label
+       :required required
+       :on-change #(on-change (.. % -target -value))}]]))
+
+
+(defn- payout-bank-info []
+  [:div
+   [:h3 "Bank Information"]
+   [:div.columns
+    [:div.column
+     [payout-field {:k        :routing-number
+                    :label    "Routing Number:"
+                    :help     "Please enter your 9 digit routing number"
+                    :required true}]]
+    [:div.column
+     [payout-field {:k        :account-number
+                    :label    "Account Number:"
+                    :help     "Please enter your 12 digit account number"
+                    :required true}]]]
+   [:br]])
+
+
+(defn- payout-personal-info []
+  [:div
+   [:h3 "Personal Information"]
+   [:div.columns
+    [:div.column
+     [payout-dob]]
+    [:div.column
+     [payout-field {:k        :ssn
+                    :label    "Social Security Number:"
+                    :help     "Please enter your 9 digit social security number."
+                    :required true}]]]
+   [:br]])
+
+
+(defn- payout-address-info []
+  [:div
+   [:h3 "Current Address"]
+   [:div.columns
+    [:div.column
+     [payout-field {:k        :line1
+                    :label    "Address Line1:"
+                    :help     "Please enter an address."
+                    :required true}]]
+    [:div.column
+     [payout-field {:k     :line2
+                    :label "Address Line2:"}]]]
+   [:div.columns
+    [:div.column
+     [payout-field {:k        :city
+                    :label    "City:"
+                    :help     "Please enter a City."
+                    :required true}]]
+    [:div.column
+     [payout-field {:k        :state
+                    :label    "State:"
+                    :help     "Please enter your 2 letter State code."
+                    :required true}]]]
+   [:div.columns
+    [:div.column
+     [payout-field {:k        :postal-code
+                    :label    "Postal Code:"
+                    :help     "Please enter your 5 digit postal code."
+                    :required true}]]
+    [:div.column
+     [payout-field {:k        :country
+                    :label    "Country:"
+                    :help     "Please enter your 2 letter country code."
+                    :required true}]]]])
+
+
+(defn- payout-modal-description []
+  [:div
+   [:p "If you’re getting a security deposit refund, we can make sure it happens even faster. All you need to do is put in the necessary bank and personal info and we’ll be able to deposit it directly into your account. Don’t worry, to protect your privacy we won’t store any of this information."]
+   [:br]
+   [:p "Unfortunately, this just works for US bank accounts at this time."]
+   [:br]])
+
+
+(defn- payout-modal []
+  (let [is-visible (subscribe [:modal/visible? :payout-account/modal])
+        form       (subscribe [:payout-account/form])]
+    [ant/modal
+     {:title    "Faster Security Deposit Refund"
+      :width    "40%"
+      :visible  @is-visible
+      :on-close #(dispatch [:modal/hide :payout-account/modal])
+      :footer   (r/as-element [payout-modal-footer])}
+     [payout-modal-description]
+     [payout-bank-info]
+     [payout-personal-info]
+     [payout-address-info]]))
+
+
 (defn source-settings []
   (let [autopay-on      (subscribe [:payment.sources/autopay-on?])
         autopay-allowed (subscribe [:payment.sources/can-enable-autopay?])
         card-sources    (subscribe [:payment/sources :card])
         service-source  (subscribe [:payment.sources/service-source])
-        setting-svc-src (subscribe [:ui/loading? :payment.source/set-default!])]
+        setting-svc-src (subscribe [:ui/loading? :payment.source/set-default!])
+        payout-account  (subscribe [:account/payout-account])]
     [:div.page-controls.columns
      [:div.column {:style {:padding 0}}
 
@@ -374,7 +543,14 @@
          [:span "With Autopay enabled, rent payments will automatically be withdrawn from your bank account on the "
           [:b "1st"] " of each month."])]]]
 
-     [:div.column {:style {:padding 0}}
+     (when-not @payout-account
+       [:div.column {:style {:padding 0}}
+        [ant/button
+         {:type     :primary
+          :on-click #(dispatch [:modal/show :payout-account/modal])}
+         "Add Deposit Info!"]])
+
+     [:div.column.is-6 {:style {:padding 0}}
       [:span.bold.mr2 "Pay for Services with:"]
       (if @setting-svc-src
         [ant/spin {:style {:width 150}}]
@@ -421,6 +597,7 @@
      [modal-verify-account]
      [modal-confirm-enable-autopay]
      [modal-confirm-disable-autopay]
+     [payout-modal]
      (typography/view-header
       (l10n/translate :payment-sources)
       "Edit your payment accounts, enable Autopay, and set default payment sources.")


### PR DESCRIPTION
Implements UI that
- allows a member to provide relevant bank account info to receive their security deposit refund
- allows an admin to verify the bank accounts associated with a community
- allows an admin to issue a security deposit refund to a (former) member.