### PR TITLE
Fix JSON encode warning when uploading files

### DIFF
--- a/src/clj/odin/server.clj
+++ b/src/clj/odin/server.clj
@@ -56,7 +56,8 @@
                 (string/ends-with? uri ".png")
                 (string/ends-with? uri ".js")
                 (string/ends-with? uri ".css")
-                (string/ends-with? uri ".map")))]
+                (string/ends-with? uri ".map")
+                (string/starts-with? uri "/api")))]
     (fn [{:keys [deps params uri request-method session remote-addr] :as req}]
       (when-not (-junk? uri)
         (timbre/info :web/request


### PR DESCRIPTION
@jalehman I added another conditional to the check in the function, this fixes the printing of the warning, but I'm not completely sure this is a valid solution. Please take a look. 