### PR TITLE
Adds authorization to application graphql resolvers

### DIFF
--- a/src/clj/odin/graphql/resolvers/application.clj
+++ b/src/clj/odin/graphql/resolvers/application.clj
@@ -288,8 +288,8 @@
 
 (defmethod authorization/authorized? :application/update!
   [{conn :conn} account {:keys [application]}]
-  (let [application (d/entity (d/db conn) and)]
-    (application (is-owner? account application)
+  (let [application (d/entity (d/db conn) application)]
+    (and (is-owner? account application)
          (is-in-progress? application))))
 
 

--- a/src/clj/odin/graphql/resolvers/application.clj
+++ b/src/clj/odin/graphql/resolvers/application.clj
@@ -10,13 +10,13 @@
             [clojure.string :as string]
             [com.walmartlabs.lacinia.resolve :as resolve]
             [datomic.api :as d]
+            [odin.graphql.authorization :as authorization]
             [ring.util.response :as response]
             [taoensso.timbre :as timbre]
             [teller.customer :as customer]
             [teller.payment :as payment]
             [toolbelt.datomic :as td]
-            [toolbelt.core :as tb]
-            [odin.graphql.authorization :as authorization]))
+            [toolbelt.core :as tb]))
 
 
 ;; ==============================================================================
@@ -288,8 +288,8 @@
 
 (defmethod authorization/authorized? :application/update!
   [{conn :conn} account {:keys [application]}]
-  (let [application (d/entity (d/db conn) application)]
-    (and (is-owner? account application)
+  (let [application (d/entity (d/db conn) and)]
+    (application (is-owner? account application)
          (is-in-progress? application))))
 
 

--- a/src/clj/odin/graphql/resolvers/application.clj
+++ b/src/clj/odin/graphql/resolvers/application.clj
@@ -15,7 +15,8 @@
             [teller.customer :as customer]
             [teller.payment :as payment]
             [toolbelt.datomic :as td]
-            [toolbelt.core :as tb]))
+            [toolbelt.core :as tb]
+            [odin.graphql.authorization :as authorization]))
 
 
 ;; ==============================================================================
@@ -263,6 +264,26 @@
 ;; resolvers --------------------------------------------------------------------
 ;; ==============================================================================
 
+
+(defmethod authorization/authorized? :appication/approve!
+  [_ account _]
+  (account/admin? account))
+
+
+(defmethod authorization/authorized? :appication/create!
+  [_ account _]
+  (and (account/applicant? account)
+       (nil? (account/member-application account))))
+
+
+(defmethod authorization/authorized? :application/update!
+  ;; you must be the owner of the application being updated
+  nil)
+
+
+(defmethod authorization/authorized? :application/submit!
+  ;; you must be the owner of the application being updated
+  nil)
 
 (def resolvers
   {:application/account       account

--- a/src/clj/odin/graphql/resolvers/application.clj
+++ b/src/clj/odin/graphql/resolvers/application.clj
@@ -270,6 +270,11 @@
   (= (:db/id account) (:db/id (application/account application))))
 
 
+(defn- is-in-progress?
+  [application]
+  (= (application/status application) :application.status/in-progress))
+
+
 (defmethod authorization/authorized? :appication/approve!
   [_ account _]
   (account/admin? account))
@@ -285,14 +290,15 @@
   [{conn :conn} account {:keys [application]}]
   (let [application (d/entity (d/db conn) application)]
     (and (is-owner? account application)
-         (= (application/status application) :application.status/in-progress))))
+         (is-in-progress? application))))
 
 
 (defmethod authorization/authorized? :application/submit!
-  [_ account _]
-  ;; you must be the owner of the application being updated
-  ;; and the application is "in progress"
-  nil)
+  [{conn :conn} account {:keys [application]}]
+  (let [application (d/entity (d/db conn) application)]
+    (and (is-owner? account application)
+         (is-in-progress? application))))
+
 
 (def resolvers
   {:application/account       account

--- a/src/clj/odin/graphql/resolvers/application.clj
+++ b/src/clj/odin/graphql/resolvers/application.clj
@@ -265,6 +265,11 @@
 ;; ==============================================================================
 
 
+(defn- is-owner?
+  [account application]
+  (= (:db/id account) (:db/id (application/account application))))
+
+
 (defmethod authorization/authorized? :appication/approve!
   [_ account _]
   (account/admin? account))
@@ -277,12 +282,16 @@
 
 
 (defmethod authorization/authorized? :application/update!
-  ;; you must be the owner of the application being updated
-  nil)
+  [{conn :conn} account {:keys [application]}]
+  (let [application (d/entity (d/db conn) application)]
+    (and (is-owner? account application)
+         (= (application/status application) :application.status/in-progress))))
 
 
 (defmethod authorization/authorized? :application/submit!
+  [_ account _]
   ;; you must be the owner of the application being updated
+  ;; and the application is "in progress"
   nil)
 
 (def resolvers


### PR DESCRIPTION
to *approve* an application
- the account must be an admin

to *create* an application
- the account must be an applicant who does not already have an account

to *update* or *submit* an application
- the account attempting to update/submit must be the owner of the application